### PR TITLE
Make sure fluentd is pid1, not sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,4 @@ ENV FLUENTD_CONF="fluent.conf"
 EXPOSE 24224
 
 ### docker run -p 24224 -v `pwd`/log: -v `pwd`/log:/home/ubuntu/log fluent/fluentd:latest
-CMD fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT
+CMD exec fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT


### PR DESCRIPTION
Currently fluentd runs in a `/bin/sh -c "fluentd ..."`, and signals are not being handled properly since they are going to /bin/sh and not fluent.
This should make fluentd pid1 in the container and properly handle signals.