### PR TITLE
Make fluentd be PID 1 inside container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ ENV FLUENTD_CONF="fluent.conf"
 
 EXPOSE 24224
 
-CMD fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT
+CMD exec fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT


### PR DESCRIPTION
closes #15 
On a side note , you should also consider changing how you launch fluentd.
Maybe make an intermediary script that resolves fluentd options, and than calls fluentd.
Or use [entrypoint](https://docs.docker.com/engine/reference/builder/#entrypoint).