### PR TITLE
Added expose of port 5140 commonly used for in_syslog source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,6 @@ ONBUILD COPY plugins /fluentd/plugins/
 ENV FLUENTD_OPT=""
 ENV FLUENTD_CONF="fluent.conf"
 
-EXPOSE 24224
+EXPOSE 24224, 5140
 
 CMD exec fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT


### PR DESCRIPTION
Assuming Fluentd has syslog listener from scratch why shouldn't docker container expose port 5140 commonly used for this type of source.