### PR TITLE
Fixed syntax error in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,6 @@ ONBUILD COPY plugins /fluentd/plugins/
 ENV FLUENTD_OPT=""
 ENV FLUENTD_CONF="fluent.conf"
 
-EXPOSE 24224, 5140
+EXPOSE 24224 5140
 
 CMD exec fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT


### PR DESCRIPTION
### Automated build
```
# https://hub.docker.com/r/fluent/fluentd/builds/bsmqlymn9uceu8f2xfu5beh/
Build failed: Invalid containerPort: 24224,
```

### Refs
+ https://hub.docker.com/r/fluent/fluentd/builds/
+ https://docs.docker.com/engine/reference/builder/#expose