### PR TITLE
Install ruby-bigdecimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk --no-cache --update add \
                             build-base \
                             ca-certificates \
                             ruby \
+                            ruby-bigdecimal \
                             ruby-irb \
                             ruby-dev && \
     echo 'gem: --no-document' >> /etc/gemrc && \


### PR DESCRIPTION
Alpine Linux has a `ruby-bigdecimal` package separate from `ruby` package even though you consider `bigdecimal` as a standard library which you can always use without installation.

https://pkgs.alpinelinux.org/package/edge/main/x86/ruby-bigdecimal

The plugin `fluent-plugin-bigquery` depends on `bigdecimal` just calculating `1000**4`.

I thought it's better to add a dependency for `bigdecimal` to fluent-plugin-bigquery at first. But installation of `bigdecimal` requires `ruby-dev` which is deleted in the Dockerfile.

Ruby requires `bigdecimal` automatically whenever a big number literal like `1000**4` occurs. So installing `ruby-bigdecimal` is helpful not to face `LoadError`.