### PR TITLE
Delete local gem cache to decrease 2.4MB of image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk --no-cache --update add \
     gem install oj && \
     gem install fluentd -v 0.12.28 && \
     apk del build-base ruby-dev && \
-    rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
+    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /usr/lib/ruby/gems/*/cache/*.gem
 
 RUN adduser -D -g '' -u 1000 -h /home/fluent fluent
 RUN chown -R fluent:fluent /home/fluent


### PR DESCRIPTION
Files at `/usr/lib/ruby/gems/*/cache/` are unnecessary to keep.