### PR TITLE
Update "How to build your own image" documents

### DIFF
--- a/Dockerfile.sample
+++ b/Dockerfile.sample
@@ -1,0 +1,13 @@
+FROM fluent/fluentd:latest-onbuild
+MAINTAINER your_name <...>
+USER fluent
+WORKDIR /home/fluent
+ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
+
+RUN apk --no-cache --update add build-base && \
+    gem install fluent-plugin-secure-forward && \
+    apk del build-base && rm -rf /home/fluent/.gem/ruby/2.3.0/cache/*.gem && gem sources -c
+EXPOSE 24284
+
+RUN apk del build-base && rm -rf /home/fluent/.gem/ruby/2.3.0/cache/*.gem && gem sources -c
+CMD fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT

--- a/Dockerfile.sample
+++ b/Dockerfile.sample
@@ -1,13 +1,17 @@
 FROM fluent/fluentd:latest-onbuild
-MAINTAINER your_name <...>
-USER fluent
+MAINTAINER YOUR_NAME <...@...>
 WORKDIR /home/fluent
 ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
 
-RUN apk --no-cache --update add build-base && \
-    gem install fluent-plugin-secure-forward && \
-    apk del build-base && rm -rf /home/fluent/.gem/ruby/2.3.0/cache/*.gem && gem sources -c
+USER root
+RUN apk --no-cache --update add sudo build-base ruby-dev && \
+
+    sudo -u fluent gem install fluent-plugin-secure-forward && \
+
+    rm -rf /home/fluent/.gem/ruby/2.3.0/cache/*.gem && sudo -u fluent gem sources -c && \
+    apk del sudo build-base ruby-dev && rm -rf /var/cache/apk/*
+
 EXPOSE 24284
 
-RUN apk del build-base && rm -rf /home/fluent/.gem/ruby/2.3.0/cache/*.gem && gem sources -c
-CMD fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT
+USER fluent
+CMD exec fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ USER fluent
 WORKDIR /home/fluent
 ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
 RUN gem install fluent-plugin-secure-forward
+RUN rm -rf /home/fluent/.gem/ruby/2.3.0/cache/*.gem && gem sources -c
 EXPOSE 24284
 CMD fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT
 ```

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ curl https://raw.githubusercontent.com/fluent/fluentd-docker-image/master/Docker
 
 Documentation of `fluent.conf` is available at [docs.fluentd.org](http://docs.fluentd.org/).
 
-### 4. Optional: customize Dockerfile to install plugins
+### 4. Customize Dockerfile to install plugins (optional)
 
-You can use [Fluentd plugins](http://www.fluentd.org/plugins) by installing them in Dockerfile. Sample Dockerfile installs `fluent-plugin-secure-forward`. To add plugins, edit `Dockerfile` as following:
+You can use [Fluentd plugins](http://www.fluentd.org/plugins) by installing them using Dockerfile. Sample Dockerfile installs `fluent-plugin-secure-forward`. To add plugins, edit `Dockerfile` as following:
 
 ```
 FROM fluent/fluentd:latest-onbuild
@@ -94,11 +94,9 @@ USER fluent
 CMD exec fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT
 ```
 
-Note: This example runs `apk --no-cache --update add build-base` so that you can install Fluentd plugins that contain native extensions. If you're sure that plugins don't include native extensions, you can omit it to make image build faster.
-
 ### 5. Build image
 
-Use `docker build` command to build the image:
+Use `docker build` command to build the image. This example names the image "custom-fluentd:latest":
 
 ```
 docker build -t custom-fluentd:latest ./
@@ -106,23 +104,23 @@ docker build -t custom-fluentd:latest ./
 
 ### 6. Testing
 
-Once the image is built, it's ready to run. Following command runs Fluentd sharing `./log` directory with the host machine:
+Once the image is built, it's ready to run. Following commands run Fluentd sharing `./log` directory with the host machine:
 
 ```
 mkdir log
 docker run -it --rm --name custom-docker-fluent-logger -v `pwd`/log:/fluentd/log custom-fluentd:latest
 ```
 
-Open another terminal and type following command to inspect IP address of the container. Fluentd is running on this IP address:
+Open another terminal and type following command to inspect IP address. Fluentd is running on this IP address:
 
 ```
 docker inspect -f '{{.NetworkSettings.IPAddress}}' custom-docker-fluent-logger
 ```
 
-Let's start another docker container and send its logs to Fluentd.
+Let's try to use another docker container to send its logs to Fluentd.
 
 ```
-docker run --log-driver=fluentd --log-opt fluentd-address=FLUENTD.ADD.RE.SS:24224 python:alpine echo "Hello Fluentd"
+docker run --log-driver=fluentd --log-opt fluentd-address=FLUENTD.ADD.RE.SS:24224 python:alpine echo Hello
 docker kill -s USR1 custom-docker-fluent-logger
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ USER fluent
 CMD exec fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT
 ```
 
+Note: This example runs `apk add build-base ruby-dev` so that you can install Fluentd plugins that contain native extensions (they are removed immediately after plugin installation). If you're sure that plugins don't include native extensions, you can omit it to make image build faster.
+
 ### 5. Build image
 
 Use `docker build` command to build the image. This example names the image "custom-fluentd:latest":
@@ -121,7 +123,7 @@ Let's try to use another docker container to send its logs to Fluentd.
 
 ```
 docker run --log-driver=fluentd --log-opt fluentd-address=FLUENTD.ADD.RE.SS:24224 python:alpine echo Hello
-docker kill -s USR1 custom-docker-fluent-logger
+docker kill -s USR1 custom-docker-fluent-logger  # force flush buffered logs
 ```
 
 (replace `FLUENTD.ADD.RE.SS` with actual IP address you inspected at the previous step)

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ mkdir plugins
 curl https://raw.githubusercontent.com/fluent/fluentd-docker-image/master/Dockerfile.sample > Dockerfile
 ```
 
-### 3. Customize fluent.conf
+### 2. Customize fluent.conf
 
 Documentation of `fluent.conf` is available at [docs.fluentd.org](http://docs.fluentd.org/).
 
-### 4. Customize Dockerfile to install plugins (optional)
+### 3. Customize Dockerfile to install plugins (optional)
 
 You can use [Fluentd plugins](http://www.fluentd.org/plugins) by installing them using Dockerfile. Sample Dockerfile installs `fluent-plugin-secure-forward`. To add plugins, edit `Dockerfile` as following:
 
@@ -96,7 +96,7 @@ CMD exec fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT
 
 Note: This example runs `apk add build-base ruby-dev` so that you can install Fluentd plugins that contain native extensions (they are removed immediately after plugin installation). If you're sure that plugins don't include native extensions, you can omit it to make image build faster.
 
-### 5. Build image
+### 4. Build image
 
 Use `docker build` command to build the image. This example names the image "custom-fluentd:latest":
 
@@ -104,7 +104,7 @@ Use `docker build` command to build the image. This example names the image "cus
 docker build -t custom-fluentd:latest ./
 ```
 
-### 6. Testing
+### 5. Test it
 
 Once the image is built, it's ready to run. Following commands run Fluentd sharing `./log` directory with the host machine:
 


### PR DESCRIPTION
Improves documentation so that any docker users can use and customize Fluentd container.

* full step-by-step guide
* added Dockerfile.sample
* `CMD fluentd` needs to be `CMD exec fluentd` to make signals work
* apk needs root to run. following steps installing gems needs sudo to run using fluent user. they should run using single `RUN` so that size of layers are kept small
* `/var/cache/apk/*` can be cleaned up to remove package index files
* added `kill -s USR1` to force flush buffered logs. this is conservative barrier to avoid unnecessary confusion

This pull-request assumes that #45 is merged.