### PR TITLE
Install and load Jemalloc memory allocator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,18 +10,19 @@ RUN apk --no-cache --update add \
                             ca-certificates \
                             ruby \
                             ruby-irb \
-                            ruby-dev && \
+                            ruby-dev \
+                            openssl && \
     echo 'gem: --no-document' >> /etc/gemrc && \
     gem install oj && \
     gem install json && \
     gem install fluentd -v 0.12.29 && \
-    wget http://www.canonware.com/download/jemalloc/jemalloc-4.2.1.tar.bz2 &&\
-    tar -xjf jemalloc-4.2.1.tar.bz2 && cd jemalloc-4.2.1/ && \
+    wget -O /tmp/jemalloc-4.3.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/4.3.0/jemalloc-4.3.0.tar.bz2 && \
+    cd /tmp && tar -xjf jemalloc-4.3.0.tar.bz2  && cd jemalloc-4.3.0/ && \
     ./configure && make && \
-    mv lib/libjemalloc.so.2 /usr/lib && cd / && rm -rf /jemalloc && \
-    apk del build-base ruby-dev && \
-    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /usr/lib/ruby/gems/*/cache/*.gem \
-    /jemalloc-4.2.1 /jemalloc-4.2.1.tar.bz2
+    mv lib/libjemalloc.so.2 /usr/lib && cd / && \
+    apk del build-base ruby-dev openssl && \
+    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /usr/lib/ruby/gems/*/cache/*.gem
+
 
 RUN adduser -D -g '' -u 1000 -h /home/fluent fluent
 RUN chown -R fluent:fluent /home/fluent

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,14 @@ RUN apk --no-cache --update add \
     gem install oj && \
     gem install json && \
     gem install fluentd -v 0.12.29 && \
+    mkdir -p /tmp/jemalloc && \
+    wget http://www.canonware.com/download/jemalloc/jemalloc-4.2.1.tar.bz2 &&\
+    tar -xjf jemalloc-4.2.1.tar.bz2 && cd jemalloc-4.2.1/ && \
+    ./configure && make && \
+    mv lib/libjemalloc.so.2 /usr/lib && cd / && rm -rf /jemalloc && \
     apk del build-base ruby-dev && \
-    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /usr/lib/ruby/gems/*/cache/*.gem
+    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /usr/lib/ruby/gems/*/cache/*.gem \
+    /jemalloc-4.2.1 /jemalloc-4.2.1.tar.bz2
 
 RUN adduser -D -g '' -u 1000 -h /home/fluent fluent
 RUN chown -R fluent:fluent /home/fluent
@@ -38,8 +44,10 @@ ENV GEM_PATH /home/fluent/.gem/ruby/2.3.0:$GEM_PATH
 
 COPY fluent.conf /fluentd/etc/
 
+# Environment variables
 ENV FLUENTD_OPT=""
 ENV FLUENTD_CONF="fluent.conf"
+ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
 
 EXPOSE 24224 5140
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN apk --no-cache --update add \
     gem install oj && \
     gem install json && \
     gem install fluentd -v 0.12.29 && \
-    mkdir -p /tmp/jemalloc && \
     wget http://www.canonware.com/download/jemalloc/jemalloc-4.2.1.tar.bz2 &&\
     tar -xjf jemalloc-4.2.1.tar.bz2 && cd jemalloc-4.2.1/ && \
     ./configure && make && \


### PR DESCRIPTION
This patch downloads Jemalloc-4.2.1 and install the shared library
libjemalloc.so.2 into /usr/lib, then it set the proper LD_PRELOAD
environment variable. When Fluentd runs the library is loaded:

root@monotop:/proc/29758# cat maps |grep jemalloc
7fc973093000-7fc9732e3000 r-xp 00000000 fc:09 394085 /usr/lib/libjemalloc.so.2
7fc9732e3000-7fc9732e6000 r--p 00050000 fc:09 394085 /usr/lib/libjemalloc.so.2
7fc9732e6000-7fc9732e7000 rw-p 00053000 fc:09 394085 /usr/lib/libjemalloc.so.2

note: Jemalloc is required to avoid high memory fragmentation.

Signed-off-by: Eduardo Silva eduardo@treasure-data.com
