### PR TITLE
Set uid of user fluent at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,45 @@
 FROM alpine:3.4
 MAINTAINER TAGOMORI Satoshi <tagomoris@gmail.com>
+
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.1"
+ENV FLUENTD_VERSION=0.12.29 DUMB_INIT_VERSION=1.2.0 GOSU_VERSION=1.10 RUBY_VERSION=2.3.0
+
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
 # therefore an 'apk delete build*' has no effect
-RUN apk --no-cache --update add \
-                            build-base \
-                            ca-certificates \
-                            ruby \
-                            ruby-irb \
-                            ruby-dev && \
-    echo 'gem: --no-document' >> /etc/gemrc && \
-    gem install oj && \
-    gem install json && \
-    gem install fluentd -v 0.12.29 && \
-    apk del build-base ruby-dev && \
-    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /usr/lib/ruby/gems/*/cache/*.gem
+RUN set -x \
+&&  apk --no-cache --update add build-base ca-certificates ruby ruby-irb ruby-dev curl \
+&&  echo 'gem: --no-document' >> /etc/gemrc \
+&&  gem install oj \
+&&  gem install json \
+&&  gem install fluentd -v ${FLUENTD_VERSION} \
+&&  curl -sSL https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64 > /usr/bin/gosu \
+&&  curl -sSL https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64 > /usr/bin/dumb-init \
+&&  apk del build-base ruby-dev curl \
+&&  rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /usr/lib/ruby/gems/*/cache/*.gem
 
-RUN adduser -D -g '' -u 1000 -h /home/fluent fluent
-RUN chown -R fluent:fluent /home/fluent
+RUN chmod +x /usr/bin/gosu
+RUN chmod +x /usr/bin/dumb-init
+
+RUN mkdir -p /home/fluent
+# Tell ruby to install packages as use
+RUN echo "gem: --user-install --no-document" >> /home/fluent/.gemrc
+ENV PATH /home/fluent/.gem/ruby/${RUBY_VERSION}/bin:$PATH
+ENV GEM_PATH /home/fluent/.gem/ruby/${RUBY_VERSION}:$GEM_PATH
 
 # for log storage (maybe shared with host)
 RUN mkdir -p /fluentd/log
 # configuration/plugins path (default: copied from .)
 RUN mkdir -p /fluentd/etc /fluentd/plugins
 
-RUN chown -R fluent:fluent /fluentd
-
-USER fluent
-WORKDIR /home/fluent
-
-# Tell ruby to install packages as user
-RUN echo "gem: --user-install --no-document" >> ~/.gemrc
-ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
-ENV GEM_PATH /home/fluent/.gem/ruby/2.3.0:$GEM_PATH
-
 COPY fluent.conf /fluentd/etc/
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
 
 ENV FLUENTD_OPT=""
 ENV FLUENTD_CONF="fluent.conf"
 
 EXPOSE 24224 5140
 
-CMD exec fluentd -c /fluentd/etc/$FLUENTD_CONF -p /fluentd/plugins $FLUENTD_OPT
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/dumb-init /bin/sh
+
+uid=${FLUENT_UID:-1000}
+
+# check if a old fluent user exists and delete it since alpine 3.4 has no usermod command
+cat /etc/passwd | grep fluent
+if [[ "${?}" == "0" ]]; then
+    deluser fluent
+fi
+
+# (re)add the fluent user with $FLUENT_UID
+adduser -D -g '' -u ${uid} -h /home/fluent fluent
+
+# chown data folders
+chown -R fluent /home/fluent
+chown -R fluent /fluentd
+
+gosu fluent fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT "$@"


### PR DESCRIPTION
I reworked the docker image to allow setting the uid of the user fluent at runtime 
and handle file ownership to avoid problems with host mounts. 

The image now supports setting the uid of fluent with the env FLUENT_UID (defaults to 1000).
The envs FLUENTD_OPT and FLUENTD_CONF are still supported but the image can now be run with fluentds CLI parameters.

I added [dumb-init](https://github.com/Yelp/dumb-init) and [gosu](https://github.com/tianon/gosu) as init system and to handel the user switching.

```
docker run -e FLUENT_UID=1234 fluent/fluentd -c /etc/your-fluentd.conf
```

Changes:
* use envs with software versions for easier maintenance
* add dumb-init and gosu
* added an entrypoint script to create fluent user at runtime and chown data folders
* moved the user creation from the Dockerfile into entrypoint.sh
* run dumb-init as entrypoint to enable parameter handling

If want to merge this pull request upstream let me know and i will add documentation.