### PR TITLE
Delete `apk --update` and `rm /var/cache/apk/*`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,18 @@ LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
 # therefore an 'apk delete build*' has no effect
-RUN apk --no-cache --update add \
-                            build-base \
-                            ca-certificates \
-                            ruby \
-                            ruby-irb \
-                            ruby-dev && \
+RUN apk --no-cache add \
+                   build-base \
+                   ca-certificates \
+                   ruby \
+                   ruby-irb \
+                   ruby-dev && \
     echo 'gem: --no-document' >> /etc/gemrc && \
     gem install oj && \
     gem install json && \
     gem install fluentd -v 0.12.29 && \
     apk del build-base ruby-dev && \
-    rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /usr/lib/ruby/gems/*/cache/*.gem
+    rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
 
 RUN adduser -D -g '' -u 1000 -h /home/fluent fluent
 RUN chown -R fluent:fluent /home/fluent

--- a/Dockerfile.sample
+++ b/Dockerfile.sample
@@ -4,12 +4,12 @@ WORKDIR /home/fluent
 ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
 
 USER root
-RUN apk --no-cache --update add sudo build-base ruby-dev && \
+RUN apk --no-cache add sudo build-base ruby-dev && \
 
     sudo -u fluent gem install fluent-plugin-secure-forward && \
 
     rm -rf /home/fluent/.gem/ruby/2.3.0/cache/*.gem && sudo -u fluent gem sources -c && \
-    apk del sudo build-base ruby-dev && rm -rf /var/cache/apk/*
+    apk del sudo build-base ruby-dev
 
 EXPOSE 24284
 

--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ ENV PATH /home/fluent/.gem/ruby/2.3.0/bin:$PATH
 # cutomize following "gem install fluent-plugin-..." line as you wish
 
 USER root
-RUN apk --no-cache --update add sudo build-base ruby-dev && \
+RUN apk --no-cache add sudo build-base ruby-dev && \
 
     sudo -u fluent gem install fluent-plugin-elasticsearch fluent-plugin-record-reformer && \
 
     rm -rf /home/fluent/.gem/ruby/2.3.0/cache/*.gem && sudo -u fluent gem sources -c && \
-    apk del sudo build-base ruby-dev && rm -rf /var/cache/apk/*
+    apk del sudo build-base ruby-dev
 
 EXPOSE 24284
 


### PR DESCRIPTION
apk --no-cache is allows users to install packages with an index that is updated and used on-the-fly and not cached locally.
This avoids the need to use --update and remove /var/cache/apk/* when done installing packages.

Refer:[Disabling Cache](https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache) at docker-alpine.

Build an image with a new Dockerfile and run it:

```
$ docker build -t suzukaze/fluentd:0.12 .
$ docker run -it --rm suzukaze/fluentd:0.12 sh
~ $ ls /var/cache/apk
~ $
```

/var/cache/apk directory is empty.

