### PR TITLE
Minor documentation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Documentation of `fluent.conf` is available at [docs.fluentd.org][3].
 ### 3. Customize Dockerfile to install plugins (optional)
 
 You can install [Fluentd plugins][4] using Dockerfile.
-Sample Dockerfile installs `fluent-plugin-elasticsearch` and 
+Sample Dockerfile installs `fluent-plugin-elasticsearch` and
 `fluent-plugin-record-reformer`.
 To add plugins, edit `Dockerfile` as following:
 
@@ -184,12 +184,11 @@ USER root
 
 RUN apk add --update --virtual .build-deps \
         sudo build-base ruby-dev \
-
- # cutomize following instruction as you wish
- && sudo -u fluent gem install \ 
+ `# customize following instruction as you wish` \
+ && sudo -u fluent gem install \
         fluent-plugin-elasticsearch \
         fluent-plugin-record-reformer \
-
+ `# retain remaining lines to minimize size ` \
  && sudo -u fluent gem sources --clear-all \
  && apk del .build-deps \
  && rm -rf /var/cache/apk/* \
@@ -210,12 +209,11 @@ USER root
 RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
-
- # cutomize following instruction as you wish
+ `# customize following instruction as you wish` \
  && sudo -u fluent gem install \
         fluent-plugin-elasticsearch \
         fluent-plugin-record-reformer \
-
+ `# retain remaining lines to minimize size ` \
  && sudo -u fluent gem sources --clear-all \
  && SUDO_FORCE_REMOVE=yes \
     apt-get purge -y --auto-remove \
@@ -252,8 +250,8 @@ Once the image is built, it's ready to run.
 Following commands run Fluentd sharing `./log` directory with the host machine:
 
 ```bash
-mkdir log
-docker run -it --rm --name custom-docker-fluent-logger -v `pwd`/log:/fluentd/log custom-fluentd:latest
+mkdir -p log
+docker run -it --rm --name custom-docker-fluent-logger -v $(pwd)/log:/fluentd/log custom-fluentd:latest
 ```
 
 Open another terminal and type following command to inspect IP address.
@@ -266,7 +264,7 @@ docker inspect -f '{{.NetworkSettings.IPAddress}}' custom-docker-fluent-logger
 Let's try to use another docker container to send its logs to Fluentd.
 
 ```bash
-docker run --log-driver=fluentd --log-opt fluentd-address=FLUENTD.ADD.RE.SS:24224 python:alpine echo Hello
+docker run --log-driver=fluentd --log-opt tag="docker.{{.ID}}" --log-opt fluentd-address=FLUENTD.ADD.RE.SS:24224 python:alpine echo Hello
 # and force flush buffered logs
 docker kill -s USR1 custom-docker-fluent-logger
 ```

--- a/README.md
+++ b/README.md
@@ -182,13 +182,15 @@ FROM fluent/fluentd:onbuild
 
 USER root
 
+# below RUN includes two plugins as examples
+# elasticsearch and record-reformer are not required
+# you may customize including plugins as you wish
+
 RUN apk add --update --virtual .build-deps \
         sudo build-base ruby-dev \
- `# customize following instruction as you wish` \
  && sudo -u fluent gem install \
         fluent-plugin-elasticsearch \
         fluent-plugin-record-reformer \
- `# retain remaining lines to minimize size ` \
  && sudo -u fluent gem sources --clear-all \
  && apk del .build-deps \
  && rm -rf /var/cache/apk/* \
@@ -206,14 +208,16 @@ FROM fluent/fluentd:debian-onbuild
 
 USER root
 
+# below RUN includes two plugins as examples
+# elasticsearch and record-reformer are not required
+# you may customize including plugins as you wish
+
 RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
- `# customize following instruction as you wish` \
  && sudo -u fluent gem install \
         fluent-plugin-elasticsearch \
         fluent-plugin-record-reformer \
- `# retain remaining lines to minimize size ` \
  && sudo -u fluent gem sources --clear-all \
  && SUDO_FORCE_REMOVE=yes \
     apt-get purge -y --auto-remove \


### PR DESCRIPTION
The default image fluent configuration assumes that docker source forward will be tagged with `docker.`, but the instructions do not tell you how to prefix `docker.` for the tag. I was confused by this in fluent/fluentd#1543 and decided to update the documentation for others.

At the same time, the example Dockerfile will not execute properly because the bash comments are evaluated inline, instead of line terminating. I placed the line terminating comments inside of backticks so that execution will proceed properly despite the comments presence.

Thank you for an excellent product! I have really enjoyed using fluentd. Very nice work!