### PR TITLE
Graceful shutdown

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -106,4 +106,4 @@ EXPOSE 24224 5140
 
 ENTRYPOINT ["/bin/entrypoint.sh"]
 
-CMD fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT
+CMD exec fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT

--- a/entrypoint.sh.erb
+++ b/entrypoint.sh.erb
@@ -22,7 +22,7 @@ chown -R fluent /home/fluent
 chown -R fluent /fluentd
 
 <% if is_alpine %>
-su-exec fluent "$@"
+exec su-exec fluent "$@"
 <% else %>
-gosu fluent "$@"
+exec gosu fluent "$@"
 <% end %>

--- a/v0.12/alpine-onbuild/Dockerfile
+++ b/v0.12/alpine-onbuild/Dockerfile
@@ -52,4 +52,4 @@ EXPOSE 24224 5140
 
 ENTRYPOINT ["/bin/entrypoint.sh"]
 
-CMD fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT
+CMD exec fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT

--- a/v0.12/alpine-onbuild/entrypoint.sh
+++ b/v0.12/alpine-onbuild/entrypoint.sh
@@ -15,4 +15,4 @@ adduser -D -g '' -u ${uid} -h /home/fluent fluent
 chown -R fluent /home/fluent
 chown -R fluent /fluentd
 
-su-exec fluent "$@"
+exec su-exec fluent "$@"

--- a/v0.12/alpine/Dockerfile
+++ b/v0.12/alpine/Dockerfile
@@ -50,4 +50,4 @@ EXPOSE 24224 5140
 
 ENTRYPOINT ["/bin/entrypoint.sh"]
 
-CMD fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT
+CMD exec fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT

--- a/v0.12/alpine/entrypoint.sh
+++ b/v0.12/alpine/entrypoint.sh
@@ -15,4 +15,4 @@ adduser -D -g '' -u ${uid} -h /home/fluent fluent
 chown -R fluent /home/fluent
 chown -R fluent /fluentd
 
-su-exec fluent "$@"
+exec su-exec fluent "$@"

--- a/v0.12/debian-onbuild/Dockerfile
+++ b/v0.12/debian-onbuild/Dockerfile
@@ -70,4 +70,4 @@ EXPOSE 24224 5140
 
 ENTRYPOINT ["/bin/entrypoint.sh"]
 
-CMD fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT
+CMD exec fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT

--- a/v0.12/debian-onbuild/entrypoint.sh
+++ b/v0.12/debian-onbuild/entrypoint.sh
@@ -16,4 +16,4 @@ export HOME=/home/fluent
 chown -R fluent /home/fluent
 chown -R fluent /fluentd
 
-gosu fluent "$@"
+exec gosu fluent "$@"

--- a/v0.12/debian/Dockerfile
+++ b/v0.12/debian/Dockerfile
@@ -68,4 +68,4 @@ EXPOSE 24224 5140
 
 ENTRYPOINT ["/bin/entrypoint.sh"]
 
-CMD fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT
+CMD exec fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT

--- a/v0.12/debian/entrypoint.sh
+++ b/v0.12/debian/entrypoint.sh
@@ -16,4 +16,4 @@ export HOME=/home/fluent
 chown -R fluent /home/fluent
 chown -R fluent /fluentd
 
-gosu fluent "$@"
+exec gosu fluent "$@"

--- a/v0.14/alpine-onbuild/Dockerfile
+++ b/v0.14/alpine-onbuild/Dockerfile
@@ -52,4 +52,4 @@ EXPOSE 24224 5140
 
 ENTRYPOINT ["/bin/entrypoint.sh"]
 
-CMD fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT
+CMD exec fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT

--- a/v0.14/alpine-onbuild/entrypoint.sh
+++ b/v0.14/alpine-onbuild/entrypoint.sh
@@ -15,4 +15,4 @@ adduser -D -g '' -u ${uid} -h /home/fluent fluent
 chown -R fluent /home/fluent
 chown -R fluent /fluentd
 
-su-exec fluent "$@"
+exec su-exec fluent "$@"

--- a/v0.14/alpine/Dockerfile
+++ b/v0.14/alpine/Dockerfile
@@ -50,4 +50,4 @@ EXPOSE 24224 5140
 
 ENTRYPOINT ["/bin/entrypoint.sh"]
 
-CMD fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT
+CMD exec fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT

--- a/v0.14/alpine/entrypoint.sh
+++ b/v0.14/alpine/entrypoint.sh
@@ -15,4 +15,4 @@ adduser -D -g '' -u ${uid} -h /home/fluent fluent
 chown -R fluent /home/fluent
 chown -R fluent /fluentd
 
-su-exec fluent "$@"
+exec su-exec fluent "$@"

--- a/v0.14/debian-onbuild/Dockerfile
+++ b/v0.14/debian-onbuild/Dockerfile
@@ -70,4 +70,4 @@ EXPOSE 24224 5140
 
 ENTRYPOINT ["/bin/entrypoint.sh"]
 
-CMD fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT
+CMD exec fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT

--- a/v0.14/debian-onbuild/entrypoint.sh
+++ b/v0.14/debian-onbuild/entrypoint.sh
@@ -16,4 +16,4 @@ export HOME=/home/fluent
 chown -R fluent /home/fluent
 chown -R fluent /fluentd
 
-gosu fluent "$@"
+exec gosu fluent "$@"

--- a/v0.14/debian/Dockerfile
+++ b/v0.14/debian/Dockerfile
@@ -68,4 +68,4 @@ EXPOSE 24224 5140
 
 ENTRYPOINT ["/bin/entrypoint.sh"]
 
-CMD fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT
+CMD exec fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins $FLUENTD_OPT

--- a/v0.14/debian/entrypoint.sh
+++ b/v0.14/debian/entrypoint.sh
@@ -16,4 +16,4 @@ export HOME=/home/fluent
 chown -R fluent /home/fluent
 chown -R fluent /fluentd
 
-gosu fluent "$@"
+exec gosu fluent "$@"


### PR DESCRIPTION
This change attempts to solve #92. Once the shell scripts have bootstrapped the container, they are no longer required. I've added `exec` to both the shell scripts so that the `fluentd` process replaces them instead of becoming a child process of them.

It seemed reasonable to add `exec` to `entrypoint.sh`. It didn't feel as good when adding the `exec` to the `CMD`. I hope if anyone is overriding the `CMD` that they are aware they might be breaking graceful shutdown. What do you think?

I repeated my tests with one of the containers I've built from this branch.

Did we get rid of those `sh` processes?

```
# docker build -t fluentd-graceful-shutdown-fix .
# docker run -d --name fluentd fluentd-graceful-shutdown-fix
# docker exec fluentd pstree -p
entrypoint.sh(1)---fluentd(7)---fluentd(16)
```

We can see that fluentd is a child of PID1 now, so it should be managed by `dumb-init`.

What happens when we stop it?

```
# strace -e trace=signal $(docker top fluentd | tail -n +2 | awk ' { x=x" -p "
$1 } END { print x }') 2>&1 | grep "+++" > /tmp/trace &
# docker stop fluentd
fluentd
[1]+  Done                       strace -e trace=signal $(...) 2>&1 | grep "+++" 1>/tmp/trace
# cat /tmp/trace 
[pid 31164] +++ exited with 0 +++
[pid 31156] +++ exited with 0 +++
+++ exited with 0 +++
```

We can see that the fluentd processes exited cleanly.