### PR TITLE
change maintainer to label

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -9,7 +9,7 @@ FROM alpine:3.5
 <% else %>
 FROM debian:stretch-slim
 <% end %>
-MAINTAINER TAGOMORI Satoshi <tagomoris@gmail.com>
+LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.1"
 
 ENV DUMB_INIT_VERSION=1.2.0


### PR DESCRIPTION
Hey,

i changed maintainer to label, since maintainer is deprecated as of Docker Version 1.13
https://docs.docker.com/engine/deprecated/#maintainer-in-dockerfile

greetz

Benjamin
