### PR TITLE
Adding power support to travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: bash
 
+os:
+  - linux
+  - linux-ppc64le
+
 sudo: false
 
 services:
@@ -19,6 +23,22 @@ env:
   - Dockerfile=v1.2/debian
   - Dockerfile=v1.2/debian-onbuild
 
+matrix:
+  exclude:
+   - os: linux-ppc64le
+     env: 
+        - Dockerfile=v0.12/alpine
+        - Dockerfile=v0.12/alpine-onbuild
+        - Dockerfile=v0.12/debian
+        - Dockerfile=v0.12/debian-onbuild
+        - Dockerfile=v1.1/alpine-onbuild
+        - Dockerfile=v1.1/debian
+        - Dockerfile=v1.1/debian-onbuild
+        - Dockerfile=v1.2/alpine
+        - Dockerfile=v1.2/alpine-onbuild
+        - Dockerfile=v1.2/debian
+        - Dockerfile=v1.2/debian-onbuild
+    
 before_script:
   - make image DOCKERFILE=$Dockerfile VERSION=test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,22 +23,6 @@ env:
   - Dockerfile=v1.2/debian
   - Dockerfile=v1.2/debian-onbuild
 
-matrix:
-  exclude:
-   - os: linux-ppc64le
-     env: 
-        - Dockerfile=v0.12/alpine
-        - Dockerfile=v0.12/alpine-onbuild
-        - Dockerfile=v0.12/debian
-        - Dockerfile=v0.12/debian-onbuild
-        - Dockerfile=v1.1/alpine-onbuild
-        - Dockerfile=v1.1/debian
-        - Dockerfile=v1.1/debian-onbuild
-        - Dockerfile=v1.2/alpine
-        - Dockerfile=v1.2/alpine-onbuild
-        - Dockerfile=v1.2/debian
-        - Dockerfile=v1.2/debian-onbuild
-    
 before_script:
   - make image DOCKERFILE=$Dockerfile VERSION=test
 

--- a/v0.12/alpine/Dockerfile
+++ b/v0.12/alpine/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.7
 LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.1"
 
-ENV DUMB_INIT_VERSION=1.2.1
+ENV DUMB_INIT_VERSION=1.2.0
 
 ENV SU_EXEC_VERSION=0.2
 

--- a/v0.12/alpine/Dockerfile
+++ b/v0.12/alpine/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.7
 LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.1"
 
-ENV DUMB_INIT_VERSION=1.2.0
+ENV DUMB_INIT_VERSION=1.2.1
 
 ENV SU_EXEC_VERSION=0.2
 

--- a/v0.12/debian-onbuild/Dockerfile
+++ b/v0.12/debian-onbuild/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:stretch-slim
 LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.1"
 
-ENV DUMB_INIT_VERSION=1.2.0
+ENV DUMB_INIT_VERSION=1.2.1
 
 ENV GOSU_VERSION=1.10
 

--- a/v0.12/debian/Dockerfile
+++ b/v0.12/debian/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:stretch-slim
 LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.1"
 
-ENV DUMB_INIT_VERSION=1.2.0
+ENV DUMB_INIT_VERSION=1.2.1
 
 ENV GOSU_VERSION=1.10
 

--- a/v1.1/debian-onbuild/Dockerfile
+++ b/v1.1/debian-onbuild/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:stretch-slim
 LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.1"
 
-ENV DUMB_INIT_VERSION=1.2.0
+ENV DUMB_INIT_VERSION=1.2.1
 
 ENV GOSU_VERSION=1.10
 

--- a/v1.1/debian/Dockerfile
+++ b/v1.1/debian/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:stretch-slim
 LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.1"
 
-ENV DUMB_INIT_VERSION=1.2.0
+ENV DUMB_INIT_VERSION=1.2.1
 
 ENV GOSU_VERSION=1.10
 

--- a/v1.2/debian-onbuild/Dockerfile
+++ b/v1.2/debian-onbuild/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:stretch-slim
 LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.1"
 
-ENV DUMB_INIT_VERSION=1.2.0
+ENV DUMB_INIT_VERSION=1.2.1
 
 ENV GOSU_VERSION=1.10
 

--- a/v1.2/debian/Dockerfile
+++ b/v1.2/debian/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:stretch-slim
 LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.1"
 
-ENV DUMB_INIT_VERSION=1.2.0
+ENV DUMB_INIT_VERSION=1.2.1
 
 ENV GOSU_VERSION=1.10
 


### PR DESCRIPTION
Here am trying to add support for power ("ppc64le") arch to travis-ci builds , Also i have updated the "dumb-init" version to latest 1.2.1 for "debian/debian-onbuild" dockerfiles.

Also travis-job created using this change - https://travis-ci.org/ghatwala/fluentd-docker-image/builds/389559309 

Relevant git issue - https://github.com/fluent/fluentd-docker-image/issues/120

@repeatedly  - FYI , please review/comment.

This is my commit message

Signed-off-by: Amit Ghatwal <ghatwala@us.ibm.com>