### PR TITLE
declare env vars from /etc/default/fluentd

### DIFF
--- a/v1.2/debian/Dockerfile
+++ b/v1.2/debian/Dockerfile
@@ -56,7 +56,7 @@ RUN mkdir -p /fluentd/log
 # configuration/plugins path (default: copied from .)
 RUN mkdir -p /fluentd/etc /fluentd/plugins
 
-#allow env vars to be sourced from /etc/default/fluentd
+#allow env vars to be sourced from /etc/default/fluentd for automation
 ADD fluentd /etc/default/
 
 COPY fluent.conf /fluentd/etc/

--- a/v1.2/debian/Dockerfile
+++ b/v1.2/debian/Dockerfile
@@ -56,6 +56,9 @@ RUN mkdir -p /fluentd/log
 # configuration/plugins path (default: copied from .)
 RUN mkdir -p /fluentd/etc /fluentd/plugins
 
+#allow env vars to be sourced from /etc/default/fluentd
+ADD fluentd /etc/default/
+
 COPY fluent.conf /fluentd/etc/
 COPY entrypoint.sh /bin/
 RUN chmod +x /bin/entrypoint.sh


### PR DESCRIPTION
this matches the behavior td-data does with their debian package, very helpful for automation tools and record_reformer purposes in fluent conf like 
 team "#{ENV['TEAM']}"
will submit change required on entrypoint.sh as well