### PR TITLE
Signed-off-by: Jordan H. <jordanhamel@gmail.com>

### DIFF
--- a/v1.2/debian/entrypoint.sh
+++ b/v1.2/debian/entrypoint.sh
@@ -2,6 +2,14 @@
 
 uid=${FLUENT_UID:-1000}
 
+# source vars for /etc/default/fluentd if exists
+DEFAULT=/etc/default/fluent
+ if [ -r $DEFAULT ]; then
+    set -o allexport
+    source $DEFAULT
+    set +o allexport
+fi
+
 # check if a old fluent user exists and delete it
 cat /etc/passwd | grep fluent
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
source /etc/default/fluentd vars if found

replaces PR 133-135, no need to add /etc/default/fluentd file now, let users do it via automation