### PR TITLE
Remove gosu/su-exec from entrypoint.sh

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -39,16 +39,12 @@ ARG CROSS_BUILD_START="cross-build-start"
 ARG CROSS_BUILD_END="cross-build-end"
 RUN [ ${CROSS_BUILD_START} ]
 <% end %>
-<% if is_alpine %>
-ENV SU_EXEC_VERSION=0.2
-<% else %>
+<% if not is_alpine %>
 <% if is_armhf %>
 ENV TINI_VERSION=0.18.0
-ENV GOSU_VERSION=1.10-1+b2
 <% else %>
 <% if not is_windows %>
 ENV TINI_VERSION=0.18.0
-ENV GOSU_VERSION=1.10
 <% end %>
 <% end %>
 <% end %>
@@ -89,7 +85,6 @@ RUN apk update \
  && apk add --no-cache \
         ca-certificates \
         ruby ruby-irb ruby-etc ruby-webrick \
-        su-exec==${SU_EXEC_VERSION}-r0 \
         tini \
  && apk add --no-cache --virtual .build-deps \
         build-base \
@@ -100,9 +95,6 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
             ca-certificates \
             ruby \
-<% if is_armhf %>
-            gosu=${GOSU_VERSION} \
-<% end %>
  && buildDeps=" \
       make gcc g++ libc-dev \
       ruby-dev \
@@ -131,15 +123,6 @@ RUN apt-get update \
  && rm -r /usr/local/bin/tini.asc \
  && chmod +x /usr/local/bin/tini \
  && tini -h \
-<% if not is_armhf %>
- && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
- && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
- && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
- && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
- && chmod +x /usr/local/bin/gosu \
-<% end %>
- && gosu nobody true \
 <% if fluentd_ver.start_with?('1') %>
  && wget -O /tmp/jemalloc-4.5.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/4.5.0/jemalloc-4.5.0.tar.bz2 \
  && cd /tmp && tar -xjf jemalloc-4.5.0.tar.bz2 && cd jemalloc-4.5.0/ \
@@ -184,6 +167,7 @@ EXPOSE 24224 5140
 <% if is_windows %>
 ENTRYPOINT ["cmd", "/k", "fluentd", "-c", "C:\\fluent\\conf\\fluent.conf"]
 <% else %>
+USER fluent
 ENTRYPOINT ["tini",  "--", "/bin/entrypoint.sh"]
 CMD ["fluentd"]
 

--- a/entrypoint.sh.erb
+++ b/entrypoint.sh.erb
@@ -1,4 +1,3 @@
-<% is_alpine = (dockerfile.split("/").last.split("-").first == "alpine") %>
 #!/bin/sh
 
 #source vars if file exists
@@ -26,8 +25,4 @@ if [ "$1" = "fluentd" ]; then
     fi
 fi
 
-<% if is_alpine %>
-exec su-exec fluent "$@"
-<% else %>
-exec gosu fluent "$@"
-<% end %>
+exec "$@"

--- a/v0.12/alpine-onbuild/entrypoint.sh
+++ b/v0.12/alpine-onbuild/entrypoint.sh
@@ -25,4 +25,4 @@ if [ "$1" = "fluentd" ]; then
     fi
 fi
 
-exec su-exec fluent "$@"
+exec "$@"

--- a/v0.12/alpine/Dockerfile
+++ b/v0.12/alpine/Dockerfile
@@ -5,7 +5,6 @@ FROM alpine:3.8
 ARG VERSION=1.1
 LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version=${VERSION}
-ENV SU_EXEC_VERSION=0.2
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -14,7 +13,6 @@ RUN apk update \
  && apk add --no-cache \
         ca-certificates \
         ruby ruby-irb ruby-etc ruby-webrick \
-        su-exec==${SU_EXEC_VERSION}-r0 \
         tini \
  && apk add --no-cache --virtual .build-deps \
         build-base \
@@ -41,6 +39,7 @@ COPY entrypoint.sh /bin/
 ENV LD_PRELOAD=""
 EXPOSE 24224 5140
 
+USER fluent
 ENTRYPOINT ["tini",  "--", "/bin/entrypoint.sh"]
 CMD ["fluentd"]
 

--- a/v0.12/alpine/entrypoint.sh
+++ b/v0.12/alpine/entrypoint.sh
@@ -25,4 +25,4 @@ if [ "$1" = "fluentd" ]; then
     fi
 fi
 
-exec su-exec fluent "$@"
+exec "$@"

--- a/v0.12/debian-onbuild/entrypoint.sh
+++ b/v0.12/debian-onbuild/entrypoint.sh
@@ -25,4 +25,4 @@ if [ "$1" = "fluentd" ]; then
     fi
 fi
 
-exec gosu fluent "$@"
+exec "$@"

--- a/v0.12/debian/Dockerfile
+++ b/v0.12/debian/Dockerfile
@@ -6,7 +6,6 @@ ARG VERSION=1.1
 LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version=${VERSION}
 ENV TINI_VERSION=0.18.0
-ENV GOSU_VERSION=1.10
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -34,13 +33,6 @@ RUN apt-get update \
  && rm -r /usr/local/bin/tini.asc \
  && chmod +x /usr/local/bin/tini \
  && tini -h \
- && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
- && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
- && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
- && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
- && chmod +x /usr/local/bin/gosu \
- && gosu nobody true \
  && wget -O /tmp/jemalloc-4.4.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/4.4.0/jemalloc-4.4.0.tar.bz2 \
  && cd /tmp && tar -xjf jemalloc-4.4.0.tar.bz2 && cd jemalloc-4.4.0/ \
  && ./configure && make \
@@ -65,6 +57,7 @@ COPY entrypoint.sh /bin/
 ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
 EXPOSE 24224 5140
 
+USER fluent
 ENTRYPOINT ["tini",  "--", "/bin/entrypoint.sh"]
 CMD ["fluentd"]
 

--- a/v0.12/debian/entrypoint.sh
+++ b/v0.12/debian/entrypoint.sh
@@ -25,4 +25,4 @@ if [ "$1" = "fluentd" ]; then
     fi
 fi
 
-exec gosu fluent "$@"
+exec "$@"

--- a/v1.3/alpine-onbuild/entrypoint.sh
+++ b/v1.3/alpine-onbuild/entrypoint.sh
@@ -25,4 +25,4 @@ if [ "$1" = "fluentd" ]; then
     fi
 fi
 
-exec su-exec fluent "$@"
+exec "$@"

--- a/v1.3/alpine/Dockerfile
+++ b/v1.3/alpine/Dockerfile
@@ -5,7 +5,6 @@ FROM alpine:3.8
 ARG VERSION=1.1
 LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version=${VERSION}
-ENV SU_EXEC_VERSION=0.2
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -14,7 +13,6 @@ RUN apk update \
  && apk add --no-cache \
         ca-certificates \
         ruby ruby-irb ruby-etc ruby-webrick \
-        su-exec==${SU_EXEC_VERSION}-r0 \
         tini \
  && apk add --no-cache --virtual .build-deps \
         build-base \
@@ -41,6 +39,7 @@ COPY entrypoint.sh /bin/
 ENV LD_PRELOAD=""
 EXPOSE 24224 5140
 
+USER fluent
 ENTRYPOINT ["tini",  "--", "/bin/entrypoint.sh"]
 CMD ["fluentd"]
 

--- a/v1.3/alpine/entrypoint.sh
+++ b/v1.3/alpine/entrypoint.sh
@@ -25,4 +25,4 @@ if [ "$1" = "fluentd" ]; then
     fi
 fi
 
-exec su-exec fluent "$@"
+exec "$@"

--- a/v1.3/armhf/debian-onbuild/entrypoint.sh
+++ b/v1.3/armhf/debian-onbuild/entrypoint.sh
@@ -25,4 +25,4 @@ if [ "$1" = "fluentd" ]; then
     fi
 fi
 
-exec gosu fluent "$@"
+exec "$@"

--- a/v1.3/armhf/debian/Dockerfile
+++ b/v1.3/armhf/debian/Dockerfile
@@ -9,7 +9,6 @@ ARG CROSS_BUILD_START="cross-build-start"
 ARG CROSS_BUILD_END="cross-build-end"
 RUN [ ${CROSS_BUILD_START} ]
 ENV TINI_VERSION=0.18.0
-ENV GOSU_VERSION=1.10-1+b2
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -18,7 +17,6 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
             ca-certificates \
             ruby \
-            gosu=${GOSU_VERSION} \
  && buildDeps=" \
       make gcc g++ libc-dev \
       ruby-dev \
@@ -38,7 +36,6 @@ RUN apt-get update \
  && rm -r /usr/local/bin/tini.asc \
  && chmod +x /usr/local/bin/tini \
  && tini -h \
- && gosu nobody true \
  && wget -O /tmp/jemalloc-4.5.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/4.5.0/jemalloc-4.5.0.tar.bz2 \
  && cd /tmp && tar -xjf jemalloc-4.5.0.tar.bz2 && cd jemalloc-4.5.0/ \
  && ./configure && make \
@@ -63,6 +60,7 @@ COPY entrypoint.sh /bin/
 ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
 EXPOSE 24224 5140
 
+USER fluent
 ENTRYPOINT ["tini",  "--", "/bin/entrypoint.sh"]
 CMD ["fluentd"]
 

--- a/v1.3/armhf/debian/entrypoint.sh
+++ b/v1.3/armhf/debian/entrypoint.sh
@@ -25,4 +25,4 @@ if [ "$1" = "fluentd" ]; then
     fi
 fi
 
-exec gosu fluent "$@"
+exec "$@"

--- a/v1.3/debian-onbuild/entrypoint.sh
+++ b/v1.3/debian-onbuild/entrypoint.sh
@@ -25,4 +25,4 @@ if [ "$1" = "fluentd" ]; then
     fi
 fi
 
-exec gosu fluent "$@"
+exec "$@"

--- a/v1.3/debian/Dockerfile
+++ b/v1.3/debian/Dockerfile
@@ -6,7 +6,6 @@ ARG VERSION=1.1
 LABEL maintainer "TAGOMORI Satoshi <tagomoris@gmail.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version=${VERSION}
 ENV TINI_VERSION=0.18.0
-ENV GOSU_VERSION=1.10
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -34,13 +33,6 @@ RUN apt-get update \
  && rm -r /usr/local/bin/tini.asc \
  && chmod +x /usr/local/bin/tini \
  && tini -h \
- && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
- && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
- && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
- && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
- && chmod +x /usr/local/bin/gosu \
- && gosu nobody true \
  && wget -O /tmp/jemalloc-4.5.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/4.5.0/jemalloc-4.5.0.tar.bz2 \
  && cd /tmp && tar -xjf jemalloc-4.5.0.tar.bz2 && cd jemalloc-4.5.0/ \
  && ./configure && make \
@@ -65,6 +57,7 @@ COPY entrypoint.sh /bin/
 ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
 EXPOSE 24224 5140
 
+USER fluent
 ENTRYPOINT ["tini",  "--", "/bin/entrypoint.sh"]
 CMD ["fluentd"]
 

--- a/v1.3/debian/entrypoint.sh
+++ b/v1.3/debian/entrypoint.sh
@@ -25,4 +25,4 @@ if [ "$1" = "fluentd" ]; then
     fi
 fi
 
-exec gosu fluent "$@"
+exec "$@"

--- a/v1.3/windows/entrypoint.sh
+++ b/v1.3/windows/entrypoint.sh
@@ -25,4 +25,4 @@ if [ "$1" = "fluentd" ]; then
     fi
 fi
 
-exec gosu fluent "$@"
+exec "$@"


### PR DESCRIPTION
34ed7d5697edf8cfcd1af518c5764fceb3073bff removed the `FLUENT_UID` environment variable to configure the fluent user, but did not allow the container image to run as an arbitrary uid as the comment linked from the commit message suggests. This leaves the administrator with no way of configuring the identity of the user the container runs as, which is necessary if mounting host volumes into the container with restricted permissions.

Happily, `entrypoint.sh` no longer does anything that requires root access, so by simply removing `gosu`/`su-exec`, using the `-u` option with `docker run` just works. This also adds a `USER` instruction so that the default configuration with no `-u` option still works correctly.

Note that with this change, `entrypoint.sh.erb` no longer actually contains any templating. This could be renamed to `entrypoint.sh` and just symlinked to where it is used, but I'm not doing that here to keep the diff straightforward.