### PR TITLE
Fix "source: not found" with Debian-based images

### DIFF
--- a/entrypoint.sh.erb
+++ b/entrypoint.sh.erb
@@ -5,7 +5,7 @@ DEFAULT=/etc/default/fluentd
 
 if [ -r $DEFAULT ]; then
     set -o allexport
-    source $DEFAULT
+    . $DEFAULT
     set +o allexport
 fi
 


### PR DESCRIPTION
When trying to use /etc/default/fluentd, Debian's /bin/sh (dash) complains:
`source: not found`
As "source" is not implemented in all /bin/sh implementations, "." should be used instead.