### PR TITLE
Fix gem cache cleanup for debian image

### DIFF
--- a/v1.6/debian/Dockerfile
+++ b/v1.6/debian/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update \
                   -o APT::AutoRemove::RecommendsImportant=false \
                   $buildDeps \
  && rm -rf /var/lib/apt/lists/* \
- && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
+ && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /usr/local/lib/ruby/gems/*/cache/*.gem /usr/local/bundle/cache/*.gem
 
 RUN groupadd -r fluent && useradd -r -g fluent fluent \
     # for log storage (maybe shared with host)


### PR DESCRIPTION
Current stable debian image contains lot of cached gem not needed in the production:
```
$ docker run -it --rm -u 0 fluent/fluentd:v1.6.2-debian-1.0 find / -xdev -type f -name "*.gem" -ls
     8386     24 -rw-r--r--   1 root     root        23040 Dec 18  2018 /usr/local/lib/ruby/gems/2.6.0/cache/did_you_mean-1.3.0.gem
     8387     80 -rw-r--r--   1 root     root        79360 Jan 26  2018 /usr/local/lib/ruby/gems/2.6.0/cache/minitest-5.11.3.gem
     8388     20 -rw-r--r--   1 root     root        16896 Jul 25  2018 /usr/local/lib/ruby/gems/2.6.0/cache/net-telnet-0.2.0.gem
     8389     16 -rw-r--r--   1 root     root        15360 Jun 24  2018 /usr/local/lib/ruby/gems/2.6.0/cache/power_assert-1.1.3.gem
     8390     88 -rw-r--r--   1 root     root        87040 Dec  7  2018 /usr/local/lib/ruby/gems/2.6.0/cache/rake-12.3.2.gem
     8391    132 -rw-r--r--   1 root     root       131584 Dec  1  2018 /usr/local/lib/ruby/gems/2.6.0/cache/test-unit-3.2.9.gem
     8392     28 -rw-r--r--   1 root     root        28672 Feb 16  2017 /usr/local/lib/ruby/gems/2.6.0/cache/xmlrpc-0.3.0.gem
     8953   1764 -rw-r--r--   1 root     staff     1804288 Jul 12 04:48 /usr/local/bundle/cache/async-1.20.0.gem
     8954     32 -rw-r--r--   1 root     staff       31744 Jul 12 04:48 /usr/local/bundle/cache/async-http-0.46.3.gem
     8955     32 -rw-r--r--   1 root     staff       32768 Jul 12 04:48 /usr/local/bundle/cache/async-io-1.23.3.gem
     8956     16 -rw-r--r--   1 root     staff       13824 Jul 12 04:48 /usr/local/bundle/cache/console-1.4.0.gem
     8957    112 -rw-r--r--   1 root     staff      112128 Jul 12 04:49 /usr/local/bundle/cache/cool.io-1.5.4.gem
     8958     12 -rw-r--r--   1 root     staff        8704 Jul 12 04:49 /usr/local/bundle/cache/dig_rb-1.0.1.gem
     8959    452 -rw-r--r--   1 root     staff      460800 Jul 12 04:49 /usr/local/bundle/cache/fluentd-1.6.2.gem
     8960    176 -rw-r--r--   1 root     staff      177664 Jul 12 04:49 /usr/local/bundle/cache/http_parser.rb-0.6.0.gem
     8961    112 -rw-r--r--   1 root     staff      112640 Jul 12 04:48 /usr/local/bundle/cache/json-2.2.0.gem
     8962     84 -rw-r--r--   1 root     staff       82432 Jul 12 04:49 /usr/local/bundle/cache/msgpack-1.3.0.gem
     8963    100 -rw-r--r--   1 root     staff      101888 Jul 12 04:48 /usr/local/bundle/cache/nio4r-2.4.0.gem
     8964    184 -rw-r--r--   1 root     staff      186368 Jul 12 04:47 /usr/local/bundle/cache/oj-3.3.10.gem
     8965     28 -rw-r--r--   1 root     staff       28160 Jul 12 04:48 /usr/local/bundle/cache/protocol-hpack-1.4.1.gem
     8966     20 -rw-r--r--   1 root     staff       17408 Jul 12 04:48 /usr/local/bundle/cache/protocol-http-0.8.1.gem
     8967     12 -rw-r--r--   1 root     staff       11776 Jul 12 04:48 /usr/local/bundle/cache/protocol-http1-0.8.3.gem
     8968     24 -rw-r--r--   1 root     staff       24576 Jul 12 04:48 /usr/local/bundle/cache/protocol-http2-0.9.3.gem
     8969     40 -rw-r--r--   1 root     staff       38912 Jul 12 04:49 /usr/local/bundle/cache/serverengine-2.1.1.gem
     8970     12 -rw-r--r--   1 root     staff        9216 Jul 12 04:49 /usr/local/bundle/cache/sigdump-0.2.4.gem
     8971     20 -rw-r--r--   1 root     staff       19456 Jul 12 04:49 /usr/local/bundle/cache/strptime-0.2.3.gem
     8972    120 -rw-r--r--   1 root     staff      120832 Jul 12 04:49 /usr/local/bundle/cache/thread_safe-0.3.6.gem
     8973     16 -rw-r--r--   1 root     staff       14848 Jul 12 04:48 /usr/local/bundle/cache/timers-4.3.0.gem
     8974    152 -rw-r--r--   1 root     staff      153600 Jul 12 04:49 /usr/local/bundle/cache/tzinfo-1.2.5.gem
     8975    312 -rw-r--r--   1 root     staff      318976 Jul 12 04:49 /usr/local/bundle/cache/tzinfo-data-1.2019.2.gem
     8976    544 -rw-r--r--   1 root     staff      557056 Jul 12 04:49 /usr/local/bundle/cache/yajl-ruby-1.4.1.gem
```

This PR fixes that and removes the unnecessary gems.