### PR TITLE
Remove fluentd gem test folder from image

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -154,7 +154,7 @@ RUN apt-get update \
                   $buildDeps \
  && rm -rf /var/lib/apt/lists/* \
 <% end %>
- && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
+ && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /usr/lib/ruby/gems/2.*/gems/fluentd-*/test
 
 <% if is_alpine %>
 RUN addgroup -S fluent && adduser -S -g fluent fluent \


### PR DESCRIPTION
This PR removes the fluentd gem test folder from the image. The fluentd test folder includes files not needed for the final docker image, including TLS certs and keys that container image vulnerability scanners are flagging as issues.

Fixes #216 