### PR TITLE
Fix hcsshim::ImportLayer error on Docker Desktop for Windows

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -71,7 +71,7 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 
 # Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
 RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'" \
-&& choco install -y msys2 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
+&& choco install -y msys2 --version 20200522.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
 RUN refreshenv \
 && ridk install 2 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \

--- a/v1.11/windows/Dockerfile
+++ b/v1.11/windows/Dockerfile
@@ -11,7 +11,7 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 
 # Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
 RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'" \
-&& choco install -y msys2 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
+&& choco install -y msys2 --version 20200522.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
 RUN refreshenv \
 && ridk install 2 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \


### PR DESCRIPTION
This error should be occurred with MSYS2 20200602.0.0.

We can avoid this error by using MSYS2 20200522.0.0.

Fixes #222.

The workaround is provided by @flurreN.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>