### PR TITLE
Switch to slim-buster for debian arm64 build

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -36,7 +36,7 @@ ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae9
 RUN apk add curl --no-cache
 RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
 
-FROM arm64v8/ruby:2.6-buster
+FROM arm64v8/ruby:2.6-slim-buster
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/
 <% else %>
 FROM ruby:2.6-slim-buster


### PR DESCRIPTION
Fixes https://github.com/fluent/fluentd-docker-image/issues/230