### PR TITLE
Use slim image on armv7hf

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -26,7 +26,7 @@ ENV QEMU_DOWNLOAD_SHA256 47ae430b0e7c25e1bde290ac447a720e2ea6c6e78cd84e44847edda
 RUN apk add curl --no-cache
 RUN curl -sL -o qemu-3.0.0+resin-arm.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-arm.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-arm.tar.gz -C . && mv qemu-3.0.0+resin-arm/qemu-arm-static .
 
-FROM arm32v7/ruby:2.6-buster
+FROM arm32v7/ruby:2.6-slim-buster
 COPY --from=builder /go/qemu-arm-static /usr/bin/
 <% elsif is_arm64 %>
 # To set multiarch build for Docker hub automated build.

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ X86_IMAGES := \
 
 # Define images for running on ARM platforms
 ARM_IMAGES := \
-	v1.11/armhf/debian:v1.11.2-debian-armhf-1.0,v1.11-debian-armhf-1,edge-debian-armhf \
+	v1.11/armhf/debian:v1.11.2-debian-armhf-1.1,v1.11-debian-armhf-1,edge-debian-armhf \
 
 # Define images for running on ARM64 platforms
 ARM64_IMAGES := \

--- a/v1.11/armhf/debian/Dockerfile
+++ b/v1.11/armhf/debian/Dockerfile
@@ -8,7 +8,7 @@ ENV QEMU_DOWNLOAD_SHA256 47ae430b0e7c25e1bde290ac447a720e2ea6c6e78cd84e44847edda
 RUN apk add curl --no-cache
 RUN curl -sL -o qemu-3.0.0+resin-arm.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-arm.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-arm.tar.gz -C . && mv qemu-3.0.0+resin-arm/qemu-arm-static .
 
-FROM arm32v7/ruby:2.6-buster
+FROM arm32v7/ruby:2.6-slim-buster
 COPY --from=builder /go/qemu-arm-static /usr/bin/
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.11.2"

--- a/v1.11/armhf/debian/hooks/post_push
+++ b/v1.11/armhf/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.11.2-debian-armhf-1.0,v1.11-debian-armhf-1,edge-debian-armhf}; do
+for tag in {v1.11.2-debian-armhf-1.1,v1.11-debian-armhf-1,edge-debian-armhf}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done


### PR DESCRIPTION
We should use debian slim image across this repository.

I'd noticed not to be used slim images on armv7hf and arm64 while reviewing on #231.