### PR TITLE
Add Fluentd v1.12.2 images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,22 +13,22 @@
 
 IMAGE_NAME := fluent/fluentd
 X86_IMAGES := \
-	v1.12/alpine:v1.12.1-1.0,v1.12-1,edge \
-	v1.12/debian:v1.12.1-debian-1.0,v1.12-debian-1,edge-debian
+	v1.12/alpine:v1.12.2-1.0,v1.12-1,edge \
+	v1.12/debian:v1.12.2-debian-1.0,v1.12-debian-1,edge-debian
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 
 # Define images for running on ARM platforms
 ARM_IMAGES := \
-	v1.12/armhf/debian:v1.12.1-debian-armhf-1.0,v1.12-debian-armhf-1,edge-debian-armhf \
+	v1.12/armhf/debian:v1.12.2-debian-armhf-1.0,v1.12-debian-armhf-1,edge-debian-armhf \
 
 # Define images for running on ARM64 platforms
 ARM64_IMAGES := \
-	v1.12/arm64/debian:v1.12.1-debian-arm64-1.0,v1.12-debian-arm64-1,edge-debian-arm64 \
+	v1.12/arm64/debian:v1.12.2-debian-arm64-1.0,v1.12-debian-arm64-1,edge-debian-arm64 \
 
 WINDOWS_IMAGES := \
-	v1.12/windows-ltsc2019:v1.12.1-windows-ltsc2019-1.0,v1.12-windows-ltsc2019-1 \
-	v1.12/windows-2004:v1.12.1-windows-2004-1.0,v1.12-windows-2004-1 \
-	v1.12/windows-20H2:v1.12.1-windows-20H2-1.0,v1.12-windows-20H2-1
+	v1.12/windows-ltsc2019:v1.12.2-windows-ltsc2019-1.0,v1.12-windows-ltsc2019-1 \
+	v1.12/windows-2004:v1.12.2-windows-2004-1.0,v1.12-windows-2004-1 \
+	v1.12/windows-20H2:v1.12.2-windows-20H2-1.0,v1.12-windows-20H2-1
 
 ALL_IMAGES := $(X86_IMAGES) $(ARM_IMAGES) $(ARM64_IMAGES) $(WINDOWS_IMAGES)
 

--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ These tags have image version postfix. This updates many places so we need feedb
 
 Current images use fluentd v1 series.
 
-- `v1.12.1-1.0`, `v1.12-1`, `edge`
+- `v1.12.2-1.0`, `v1.12-1`, `edge`
   [(v1.12/alpine/Dockerfile)][fluentd-1-alpine]
-- `v1.12.1-debian-1.0`, `v1.12-debian-1`, `edge-debian`
+- `v1.12.2-debian-1.0`, `v1.12-debian-1`, `edge-debian`
   [(v1.12/debian/Dockerfile)][fluentd-1-debian]
-- `v1.12.1-debian-arm64-1.0`, `v1.12-debian-arm64-1`, `edge-debian-arm64`
+- `v1.12.2-debian-arm64-1.0`, `v1.12-debian-arm64-1`, `edge-debian-arm64`
   [(v1.12/arm64/debian/Dockerfile)][fluentd-1-debian-arm64]
-- `v1.12.1-debian-armhf-1.0`, `v1.12-debian-armhf-1`, `edge-debian-armhf`
+- `v1.12.2-debian-armhf-1.0`, `v1.12-debian-armhf-1`, `edge-debian-armhf`
   [(v1.12/armhf/debian/Dockerfile)][fluentd-1-debian-armhf]
-- `v1.12.1-windows-ltsc2019-1.0`, `v1.12-windows-ltsc2019-1`
+- `v1.12.2-windows-ltsc2019-1.0`, `v1.12-windows-ltsc2019-1`
   [(v1.12/windows-ltsc2019/Dockerfile)][fluentd-1-ltsc2019-windows]
-- `v1.12.1-windows-2004-1.0`, `v1.12-windows-2004-1`
+- `v1.12.2-windows-2004-1.0`, `v1.12-windows-2004-1`
   [(v1.12/windows-2004/Dockerfile)][fluentd-1-2004-windows]
-- `v1.12.1-windows-20H2-1.0`, `v1.12-windows-20H2-1`
+- `v1.12.2-windows-20H2-1.0`, `v1.12-windows-20H2-1`
   [(v1.12/windows-20H2/Dockerfile)][fluentd-1-20H2-windows]
 
 ### Old v1.4 images

--- a/v1.12/alpine/Dockerfile
+++ b/v1.12/alpine/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM alpine:3.12
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.1"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.2"
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -21,7 +21,7 @@ RUN apk update \
  && gem install json -v 2.4.1 \
  && gem install async-http -v 0.54.0 \
  && gem install ext_monitor -v 0.1.2 \
- && gem install fluentd -v 1.12.1 \
+ && gem install fluentd -v 1.12.2 \
  && gem install bigdecimal -v 1.4.4 \
  && apk del .build-deps \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /usr/lib/ruby/gems/2.*/gems/fluentd-*/test

--- a/v1.12/alpine/hooks/post_push
+++ b/v1.12/alpine/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.1-1.0,v1.12-1,edge}; do
+for tag in {v1.12.2-1.0,v1.12-1,edge}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.12/arm64/debian/Dockerfile
+++ b/v1.12/arm64/debian/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qem
 FROM arm64v8/ruby:2.6-slim-buster
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.1"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.2"
 ARG CROSS_BUILD_START="cross-build-start"
 ARG CROSS_BUILD_END="cross-build-end"
 RUN [ ${CROSS_BUILD_START} ]
@@ -33,7 +33,7 @@ RUN apt-get update \
  && gem install json -v 2.4.1 \
  && gem install async-http -v 0.54.0 \
  && gem install ext_monitor -v 0.1.2 \
- && gem install fluentd -v 1.12.1 \
+ && gem install fluentd -v 1.12.2 \
  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch" \
  && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \

--- a/v1.12/arm64/debian/hooks/post_push
+++ b/v1.12/arm64/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.1-debian-arm64-1.0,v1.12-debian-arm64-1,edge-debian-arm64}; do
+for tag in {v1.12.2-debian-arm64-1.0,v1.12-debian-arm64-1,edge-debian-arm64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.12/armhf/debian/Dockerfile
+++ b/v1.12/armhf/debian/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -sL -o qemu-3.0.0+resin-arm.tar.gz https://github.com/balena-io/qemu/re
 FROM arm32v7/ruby:2.6-slim-buster
 COPY --from=builder /go/qemu-arm-static /usr/bin/
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.1"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.2"
 ARG CROSS_BUILD_START="cross-build-start"
 ARG CROSS_BUILD_END="cross-build-end"
 RUN [ ${CROSS_BUILD_START} ]
@@ -33,7 +33,7 @@ RUN apt-get update \
  && gem install json -v 2.4.1 \
  && gem install async-http -v 0.54.0 \
  && gem install ext_monitor -v 0.1.2 \
- && gem install fluentd -v 1.12.1 \
+ && gem install fluentd -v 1.12.2 \
  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch" \
  && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \

--- a/v1.12/armhf/debian/hooks/post_push
+++ b/v1.12/armhf/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.1-debian-armhf-1.0,v1.12-debian-armhf-1,edge-debian-armhf}; do
+for tag in {v1.12.2-debian-armhf-1.0,v1.12-debian-armhf-1,edge-debian-armhf}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.12/debian/Dockerfile
+++ b/v1.12/debian/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM ruby:2.6-slim-buster
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.1"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.2"
 ENV TINI_VERSION=0.18.0
 
 # Do not split this into multiple RUN!
@@ -22,7 +22,7 @@ RUN apt-get update \
  && gem install json -v 2.4.1 \
  && gem install async-http -v 0.54.0 \
  && gem install ext_monitor -v 0.1.2 \
- && gem install fluentd -v 1.12.1 \
+ && gem install fluentd -v 1.12.2 \
  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch" \
  && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \

--- a/v1.12/debian/hooks/post_push
+++ b/v1.12/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.1-debian-1.0,v1.12-debian-1,edge-debian}; do
+for tag in {v1.12.2-debian-1.0,v1.12-debian-1,edge-debian}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.12/windows-2004/Dockerfile
+++ b/v1.12/windows-2004/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:2004
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.1"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.2"
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -18,7 +18,7 @@ RUN refreshenv \
 && gem install cool.io -v 1.5.4 --platform ruby \
 && gem install oj -v 3.3.10 \
 && gem install json -v 2.2.0 \
-&& gem install fluentd -v 1.12.1 \
+&& gem install fluentd -v 1.12.2 \
 && gem install win32-service -v 1.0.1 \
 && gem install win32-ipc -v 0.7.0 \
 && gem install win32-event -v 0.6.3 \

--- a/v1.12/windows-2004/hooks/post_push
+++ b/v1.12/windows-2004/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.1-windows-2004-1.0,v1.12-windows-2004-1}; do
+for tag in {v1.12.2-windows-2004-1.0,v1.12-windows-2004-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.12/windows-20H2/Dockerfile
+++ b/v1.12/windows-20H2/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:20H2
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.1"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.2"
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -18,7 +18,7 @@ RUN refreshenv \
 && gem install cool.io -v 1.5.4 --platform ruby \
 && gem install oj -v 3.3.10 \
 && gem install json -v 2.2.0 \
-&& gem install fluentd -v 1.12.1 \
+&& gem install fluentd -v 1.12.2 \
 && gem install win32-service -v 1.0.1 \
 && gem install win32-ipc -v 0.7.0 \
 && gem install win32-event -v 0.6.3 \

--- a/v1.12/windows-20H2/hooks/post_push
+++ b/v1.12/windows-20H2/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.1-windows-20H2-1.0,v1.12-windows-20H2-1}; do
+for tag in {v1.12.2-windows-20H2-1.0,v1.12-windows-20H2-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.12/windows-ltsc2019/Dockerfile
+++ b/v1.12/windows-ltsc2019/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.1"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.2"
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -18,7 +18,7 @@ RUN refreshenv \
 && gem install cool.io -v 1.5.4 --platform ruby \
 && gem install oj -v 3.3.10 \
 && gem install json -v 2.2.0 \
-&& gem install fluentd -v 1.12.1 \
+&& gem install fluentd -v 1.12.2 \
 && gem install win32-service -v 1.0.1 \
 && gem install win32-ipc -v 0.7.0 \
 && gem install win32-event -v 0.6.3 \

--- a/v1.12/windows-ltsc2019/hooks/post_push
+++ b/v1.12/windows-ltsc2019/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.1-windows-ltsc2019-1.0,v1.12-windows-ltsc2019-1}; do
+for tag in {v1.12.2-windows-ltsc2019-1.0,v1.12-windows-ltsc2019-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done


### PR DESCRIPTION
Fluentd v1.12.2 has been released.
We should add Fluentd v1.12.2 images.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>