### PR TITLE
Make buildable Windows Images

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -73,8 +73,10 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 
 # Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
 RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'" \
-&& choco install -y msys2 --version 20210215.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
+&& choco install -y msys2 --version 20210419.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
+# pacman -Syu is needed for updating ucrt64 repo
 RUN refreshenv \
+&& ridk exec pacman -Syu --noconfirm \
 && ridk install 2 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
 && gem install cool.io -v 1.5.4 --platform ruby \
@@ -85,7 +87,7 @@ RUN refreshenv \
 <% end %>
 && gem install json -v 2.2.0 \
 && gem install fluentd -v <%= fluentd_ver %> \
-&& gem install win32-service -v 1.0.1 \
+&& gem install win32-service -v 2.1.6 \
 && gem install win32-ipc -v 0.7.0 \
 && gem install win32-event -v 0.6.3 \
 && gem install windows-pr -v 1.2.6 \

--- a/v1.12/windows-2004/Dockerfile
+++ b/v1.12/windows-2004/Dockerfile
@@ -11,15 +11,17 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 
 # Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
 RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'" \
-&& choco install -y msys2 --version 20210215.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
+&& choco install -y msys2 --version 20210419.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
+# pacman -Syu is needed for updating ucrt64 repo
 RUN refreshenv \
+&& ridk exec pacman -Syu --noconfirm \
 && ridk install 2 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
 && gem install cool.io -v 1.5.4 --platform ruby \
 && gem install oj -v 3.3.10 \
 && gem install json -v 2.2.0 \
 && gem install fluentd -v 1.12.2 \
-&& gem install win32-service -v 1.0.1 \
+&& gem install win32-service -v 2.1.6 \
 && gem install win32-ipc -v 0.7.0 \
 && gem install win32-event -v 0.6.3 \
 && gem install windows-pr -v 1.2.6 \

--- a/v1.12/windows-20H2/Dockerfile
+++ b/v1.12/windows-20H2/Dockerfile
@@ -11,15 +11,17 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 
 # Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
 RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'" \
-&& choco install -y msys2 --version 20210215.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
+&& choco install -y msys2 --version 20210419.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
+# pacman -Syu is needed for updating ucrt64 repo
 RUN refreshenv \
+&& ridk exec pacman -Syu --noconfirm \
 && ridk install 2 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
 && gem install cool.io -v 1.5.4 --platform ruby \
 && gem install oj -v 3.3.10 \
 && gem install json -v 2.2.0 \
 && gem install fluentd -v 1.12.2 \
-&& gem install win32-service -v 1.0.1 \
+&& gem install win32-service -v 2.1.6 \
 && gem install win32-ipc -v 0.7.0 \
 && gem install win32-event -v 0.6.3 \
 && gem install windows-pr -v 1.2.6 \

--- a/v1.12/windows-ltsc2019/Dockerfile
+++ b/v1.12/windows-ltsc2019/Dockerfile
@@ -11,15 +11,17 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 
 # Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
 RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'" \
-&& choco install -y msys2 --version 20210215.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
+&& choco install -y msys2 --version 20210419.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
+# pacman -Syu is needed for updating ucrt64 repo
 RUN refreshenv \
+&& ridk exec pacman -Syu --noconfirm \
 && ridk install 2 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
 && gem install cool.io -v 1.5.4 --platform ruby \
 && gem install oj -v 3.3.10 \
 && gem install json -v 2.2.0 \
 && gem install fluentd -v 1.12.2 \
-&& gem install win32-service -v 1.0.1 \
+&& gem install win32-service -v 2.1.6 \
 && gem install win32-ipc -v 0.7.0 \
 && gem install win32-event -v 0.6.3 \
 && gem install windows-pr -v 1.2.6 \


### PR DESCRIPTION
* Use win32-service v2.1.6 gem for the latest acceptable version for
  Fluentd v1.12.2
* The latest version of msys2
* Kick `ridk exec pacman -Syu --noconfirm` before executing `ridk install 2 3`
  for updating ucrt64 repo

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>