### PR TITLE
Upgrade using MSYS2 to 20210604

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -74,9 +74,7 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 # Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
 RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'" \
 && choco install -y msys2 --version 20210604.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
-# pacman -Syu is needed for updating ucrt64 repo
 RUN refreshenv \
-&& ridk exec pacman -Syu --noconfirm \
 && ridk install 2 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
 && gem install cool.io -v 1.5.4 --platform ruby \

--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -73,7 +73,7 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 
 # Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
 RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'" \
-&& choco install -y msys2 --version 20210419.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
+&& choco install -y msys2 --version 20210604.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
 # pacman -Syu is needed for updating ucrt64 repo
 RUN refreshenv \
 && ridk exec pacman -Syu --noconfirm \

--- a/v1.12/windows-2004/Dockerfile
+++ b/v1.12/windows-2004/Dockerfile
@@ -11,10 +11,8 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 
 # Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
 RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'" \
-&& choco install -y msys2 --version 20210419.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
-# pacman -Syu is needed for updating ucrt64 repo
+&& choco install -y msys2 --version 20210604.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
 RUN refreshenv \
-&& ridk exec pacman -Syu --noconfirm \
 && ridk install 2 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
 && gem install cool.io -v 1.5.4 --platform ruby \

--- a/v1.12/windows-20H2/Dockerfile
+++ b/v1.12/windows-20H2/Dockerfile
@@ -11,10 +11,8 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 
 # Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
 RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'" \
-&& choco install -y msys2 --version 20210419.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
-# pacman -Syu is needed for updating ucrt64 repo
+&& choco install -y msys2 --version 20210604.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
 RUN refreshenv \
-&& ridk exec pacman -Syu --noconfirm \
 && ridk install 2 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
 && gem install cool.io -v 1.5.4 --platform ruby \

--- a/v1.12/windows-ltsc2019/Dockerfile
+++ b/v1.12/windows-ltsc2019/Dockerfile
@@ -11,10 +11,8 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 
 # Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
 RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'" \
-&& choco install -y msys2 --version 20210419.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
-# pacman -Syu is needed for updating ucrt64 repo
+&& choco install -y msys2 --version 20210604.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
 RUN refreshenv \
-&& ridk exec pacman -Syu --noconfirm \
 && ridk install 2 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
 && gem install cool.io -v 1.5.4 --platform ruby \


### PR DESCRIPTION
I can confirm Windows server core images are able to build with these changes.
(I tested for Fluentd v1.12.4 images for Windows server core. I'd forgotten to build them... :cry:)
Could you kindly take a look?