### PR TITLE
alpine: debian: Use the latest resolv gem

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -2,6 +2,7 @@
 <% fluentd_tag = version.dup; fluentd_tag.slice!('-onbuild') %>
 <% is_onbuild = (version.include?("onbuild")) %>
 <% is_alpine = (dockerfile.split("/").last.split("-").first == "alpine") %>
+<% is_debian = (dockerfile.split("/").last.split("-").first == "debian") %>
 <% is_armhf = (dockerfile.split("/")[1] == "armhf") %>
 <% is_arm64 = (dockerfile.split("/")[1] == "arm64") %>
 <% is_windows = (dockerfile.split("/").last.split("-").first == "windows") %>
@@ -66,6 +67,10 @@ ENV TINI_VERSION=0.18.0
 <% end %>
 <% end %>
 
+<% if is_alpine || is_debian %>
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# This hack is needed for Ruby 2.6.7, 2.7.3 and 3.0.1.
+<% end %>
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
 <% if is_windows %>

--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -124,6 +124,7 @@ RUN apt-get update \
  && gem install oj -v 2.18.3 \
 <% end %>
  && gem install json -v 2.4.1 \
+ && gem install resolv -v 0.2.1 \
 <% if fluentd_ver.start_with?('1') %>
  && gem install async-http -v 0.54.0 \
  && gem install ext_monitor -v 0.1.2 \

--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,17 @@
 
 IMAGE_NAME := fluent/fluentd
 X86_IMAGES := \
-	v1.12/alpine:v1.12.4-1.0,v1.12-1,edge \
-	v1.12/debian:v1.12.4-debian-1.0,v1.12-debian-1,edge-debian
+	v1.12/alpine:v1.12.4-1.1,v1.12-1,edge \
+	v1.12/debian:v1.12.4-debian-1.1,v1.12-debian-1,edge-debian
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 
 # Define images for running on ARM platforms
 ARM_IMAGES := \
-	v1.12/armhf/debian:v1.12.4-debian-armhf-1.0,v1.12-debian-armhf-2,edge-debian-armhf \
+	v1.12/armhf/debian:v1.12.4-debian-armhf-1.1,v1.12-debian-armhf-2,edge-debian-armhf \
 
 # Define images for running on ARM64 platforms
 ARM64_IMAGES := \
-	v1.12/arm64/debian:v1.12.4-debian-arm64-1.0,v1.12-debian-arm64-2,edge-debian-arm64 \
+	v1.12/arm64/debian:v1.12.4-debian-arm64-1.1,v1.12-debian-arm64-2,edge-debian-arm64 \
 
 WINDOWS_IMAGES := \
 	v1.12/windows-ltsc2019:v1.12.4-windows-ltsc2019-1.0,v1.12-windows-ltsc2019-1 \

--- a/v1.12/alpine/Dockerfile
+++ b/v1.12/alpine/Dockerfile
@@ -19,6 +19,7 @@ RUN apk update \
  && echo 'gem: --no-document' >> /etc/gemrc \
  && gem install oj -v 3.10.18 \
  && gem install json -v 2.4.1 \
+ && gem install resolv -v 0.2.1 \
  && gem install async-http -v 0.54.0 \
  && gem install ext_monitor -v 0.1.2 \
  && gem install fluentd -v 1.12.4 \

--- a/v1.12/alpine/Dockerfile
+++ b/v1.12/alpine/Dockerfile
@@ -5,6 +5,8 @@ FROM alpine:3.13
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.4"
 
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# This hack is needed for Ruby 2.6.7, 2.7.3 and 3.0.1.
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
 # therefore an 'apk delete' has no effect

--- a/v1.12/alpine/hooks/post_push
+++ b/v1.12/alpine/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.4-1.0,v1.12-1,edge}; do
+for tag in {v1.12.4-1.1,v1.12-1,edge}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.12/arm64/debian/Dockerfile
+++ b/v1.12/arm64/debian/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
  && echo 'gem: --no-document' >> /etc/gemrc \
  && gem install oj -v 3.10.18 \
  && gem install json -v 2.4.1 \
+ && gem install resolv -v 0.2.1 \
  && gem install async-http -v 0.54.0 \
  && gem install ext_monitor -v 0.1.2 \
  && gem install fluentd -v 1.12.4 \

--- a/v1.12/arm64/debian/Dockerfile
+++ b/v1.12/arm64/debian/Dockerfile
@@ -17,6 +17,8 @@ ARG CROSS_BUILD_END="cross-build-end"
 RUN [ ${CROSS_BUILD_START} ]
 ENV TINI_VERSION=0.18.0
 
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# This hack is needed for Ruby 2.6.7, 2.7.3 and 3.0.1.
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
 # therefore an 'apt-get purge' has no effect

--- a/v1.12/arm64/debian/hooks/post_push
+++ b/v1.12/arm64/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.4-debian-arm64-1.0,v1.12-debian-arm64-2,edge-debian-arm64}; do
+for tag in {v1.12.4-debian-arm64-1.1,v1.12-debian-arm64-2,edge-debian-arm64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.12/armhf/debian/Dockerfile
+++ b/v1.12/armhf/debian/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
  && echo 'gem: --no-document' >> /etc/gemrc \
  && gem install oj -v 3.10.18 \
  && gem install json -v 2.4.1 \
+ && gem install resolv -v 0.2.1 \
  && gem install async-http -v 0.54.0 \
  && gem install ext_monitor -v 0.1.2 \
  && gem install fluentd -v 1.12.4 \

--- a/v1.12/armhf/debian/Dockerfile
+++ b/v1.12/armhf/debian/Dockerfile
@@ -17,6 +17,8 @@ ARG CROSS_BUILD_END="cross-build-end"
 RUN [ ${CROSS_BUILD_START} ]
 ENV TINI_VERSION=0.18.0
 
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# This hack is needed for Ruby 2.6.7, 2.7.3 and 3.0.1.
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
 # therefore an 'apt-get purge' has no effect

--- a/v1.12/armhf/debian/hooks/post_push
+++ b/v1.12/armhf/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.4-debian-armhf-1.0,v1.12-debian-armhf-2,edge-debian-armhf}; do
+for tag in {v1.12.4-debian-armhf-1.1,v1.12-debian-armhf-2,edge-debian-armhf}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.12/debian/Dockerfile
+++ b/v1.12/debian/Dockerfile
@@ -6,6 +6,8 @@ LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.12.4"
 ENV TINI_VERSION=0.18.0
 
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# This hack is needed for Ruby 2.6.7, 2.7.3 and 3.0.1.
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
 # therefore an 'apt-get purge' has no effect

--- a/v1.12/debian/Dockerfile
+++ b/v1.12/debian/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update \
  && echo 'gem: --no-document' >> /etc/gemrc \
  && gem install oj -v 3.10.18 \
  && gem install json -v 2.4.1 \
+ && gem install resolv -v 0.2.1 \
  && gem install async-http -v 0.54.0 \
  && gem install ext_monitor -v 0.1.2 \
  && gem install fluentd -v 1.12.4 \

--- a/v1.12/debian/hooks/post_push
+++ b/v1.12/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.4-debian-1.0,v1.12-debian-1,edge-debian}; do
+for tag in {v1.12.4-debian-1.1,v1.12-debian-1,edge-debian}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done


### PR DESCRIPTION
This version of resolv includes the fix for CPU spike issue due to DNS
resolver.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>