### PR TITLE
MAINTAINING: windows: Add note for MSYS2

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -60,6 +60,8 @@ Built tags for debian and alpine images will be published at [TAGS page](https:/
 * RubyInstaller (only for `ridk` command)
 * Already logined in DockerHub via `docker login`
 
+**NOTE:** Using the latest version of MSYS2 is recommended. Windows Docker Engine sometimes stuck due to plenty of updates for MSYS2 packages. We should keep minimum changes on the MSYS2 installation step.
+
 #### Build procedures
 
 ```console


### PR DESCRIPTION
I added note for MSYS2 version.
This is one of the pitfalls of updating Windows Server Core images.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>