### PR TITLE
Ensure to load latest resolv 0.2.1 for debian and alpine image

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -198,6 +198,11 @@ ENV LD_PRELOAD=""
 <% else %>
 ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
 <% end %>
+<% if is_alpine || is_debian %>
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# Forcing to load specific version of resolv (instead of bundled by default) is needed for Ruby 2.6.7, 2.7.3 and 3.0.1.
+ENV RUBYLIB="/usr/local/bundle/gems/resolv-0.2.1/lib"
+<% end %>
 <% end %>
 EXPOSE 24224 5140
 

--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,17 @@
 
 IMAGE_NAME := fluent/fluentd
 X86_IMAGES := \
-	v1.12/alpine:v1.12.4-1.1,v1.12-1,edge \
-	v1.12/debian:v1.12.4-debian-1.1,v1.12-debian-1,edge-debian
+	v1.12/alpine:v1.12.4-1.2,v1.12-1,edge \
+	v1.12/debian:v1.12.4-debian-1.2,v1.12-debian-1,edge-debian
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 
 # Define images for running on ARM platforms
 ARM_IMAGES := \
-	v1.12/armhf/debian:v1.12.4-debian-armhf-1.1,v1.12-debian-armhf-2,edge-debian-armhf \
+	v1.12/armhf/debian:v1.12.4-debian-armhf-1.2,v1.12-debian-armhf-2,edge-debian-armhf \
 
 # Define images for running on ARM64 platforms
 ARM64_IMAGES := \
-	v1.12/arm64/debian:v1.12.4-debian-arm64-1.1,v1.12-debian-arm64-2,edge-debian-arm64 \
+	v1.12/arm64/debian:v1.12.4-debian-arm64-1.2,v1.12-debian-arm64-2,edge-debian-arm64 \
 
 WINDOWS_IMAGES := \
 	v1.12/windows-ltsc2019:v1.12.4-windows-ltsc2019-1.0,v1.12-windows-ltsc2019-1 \

--- a/v1.12/alpine/Dockerfile
+++ b/v1.12/alpine/Dockerfile
@@ -44,6 +44,9 @@ COPY entrypoint.sh /bin/
 ENV FLUENTD_CONF="fluent.conf"
 
 ENV LD_PRELOAD=""
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# Forcing to load specific version of resolv (instead of bundled by default) is needed for Ruby 2.6.7, 2.7.3 and 3.0.1.
+ENV RUBYLIB="/usr/local/bundle/gems/resolv-0.2.1/lib"
 EXPOSE 24224 5140
 
 USER fluent

--- a/v1.12/alpine/hooks/post_push
+++ b/v1.12/alpine/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.4-1.1,v1.12-1,edge}; do
+for tag in {v1.12.4-1.2,v1.12-1,edge}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.12/arm64/debian/Dockerfile
+++ b/v1.12/arm64/debian/Dockerfile
@@ -71,6 +71,9 @@ COPY entrypoint.sh /bin/
 ENV FLUENTD_CONF="fluent.conf"
 
 ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# Forcing to load specific version of resolv (instead of bundled by default) is needed for Ruby 2.6.7, 2.7.3 and 3.0.1.
+ENV RUBYLIB="/usr/local/bundle/gems/resolv-0.2.1/lib"
 EXPOSE 24224 5140
 
 USER fluent

--- a/v1.12/arm64/debian/hooks/post_push
+++ b/v1.12/arm64/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.4-debian-arm64-1.1,v1.12-debian-arm64-2,edge-debian-arm64}; do
+for tag in {v1.12.4-debian-arm64-1.2,v1.12-debian-arm64-2,edge-debian-arm64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.12/armhf/debian/Dockerfile
+++ b/v1.12/armhf/debian/Dockerfile
@@ -71,6 +71,9 @@ COPY entrypoint.sh /bin/
 ENV FLUENTD_CONF="fluent.conf"
 
 ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# Forcing to load specific version of resolv (instead of bundled by default) is needed for Ruby 2.6.7, 2.7.3 and 3.0.1.
+ENV RUBYLIB="/usr/local/bundle/gems/resolv-0.2.1/lib"
 EXPOSE 24224 5140
 
 USER fluent

--- a/v1.12/armhf/debian/hooks/post_push
+++ b/v1.12/armhf/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.4-debian-armhf-1.1,v1.12-debian-armhf-2,edge-debian-armhf}; do
+for tag in {v1.12.4-debian-armhf-1.2,v1.12-debian-armhf-2,edge-debian-armhf}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.12/debian/Dockerfile
+++ b/v1.12/debian/Dockerfile
@@ -60,6 +60,9 @@ COPY entrypoint.sh /bin/
 ENV FLUENTD_CONF="fluent.conf"
 
 ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# Forcing to load specific version of resolv (instead of bundled by default) is needed for Ruby 2.6.7, 2.7.3 and 3.0.1.
+ENV RUBYLIB="/usr/local/bundle/gems/resolv-0.2.1/lib"
 EXPOSE 24224 5140
 
 USER fluent

--- a/v1.12/debian/hooks/post_push
+++ b/v1.12/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.12.4-debian-1.1,v1.12-debian-1,edge-debian}; do
+for tag in {v1.12.4-debian-1.2,v1.12-debian-1,edge-debian}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done


### PR DESCRIPTION
By https://github.com/fluent/fluentd-docker-image/pull/272, latest resolv gem is installed, but it is not used.

Without this fix, officially bundled resolv is loaded in ahead, thus resolv gem is not used at all.

I've checked the fix works as expected like this:

```
<source>
 @type sample
 tag sample
</source>

<filter>
  @type record_modifier
  remove_keys _dummy_
  <record>
    _dummy_ ${record['loaded'] = $LOADED_FEATURES.collect { |entry| entry if entry.include?('resolv.rb') }.compact }
  </record>
</filter>

<match sample>
  @type stdout
</match>
```

OUTPUT:

WIth `{"message":"sample","loaded":["/usr/local/bundle/gems/resolv-0.2.1/lib/resolv.rb"]}`, it turned out that  latest resolv.rb is used.

```
% docker run -v $PWD:/fluentd/etc -it df-v12 -c /fluentd/etc/fluent.conf
fluentd -c /fluentd/etc/fluent.conf
2021-06-09 02:52:35 +0000 [info]: parsing config file is succeeded path="/fluentd/etc/fluent.conf"
2021-06-09 02:52:35 +0000 [info]: gem 'fluent-plugin-record-modifier' version '2.1.0'
2021-06-09 02:52:35 +0000 [info]: gem 'fluentd' version '1.12.4'
2021-06-09 02:52:35 +0000 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2021-06-09 02:52:35 +0000 [warn]: both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2021-06-09 02:52:35 +0000 [warn]: define <match fluent.**> to capture fluentd logs in top level is deprecated. Use <label @FLUENT_LOG> instead
2021-06-09 02:52:35 +0000 [info]: using configuration file: <ROOT>
  <source>
    @type sample
    tag "sample"
  </source>
  <filter>
    @type record_modifier
    remove_keys "_dummy_"
    <record>
      _dummy_ ${record['loaded'] = $LOADED_FEATURES.collect { |entry| entry if entry.include?('resolv.rb') }.compact }
    </record>
  </filter>
  <match sample>
    @type stdout
  </match>
</ROOT>
2021-06-09 02:52:35 +0000 [info]: starting fluentd-1.12.4 pid=7 ruby="2.6.7"
2021-06-09 02:52:35 +0000 [info]: spawn command to main:  cmdline=["/usr/local/bin/ruby", "-Eascii-8bit:ascii-8bit", "/usr/local/bundle/bin/fluentd", "-c", "/fluentd/etc/fluent.conf", "-p", "/fluentd/plugins", "--under-supervisor"]
2021-06-09 02:52:35 +0000 [info]: adding filter pattern="**" type="record_modifier"
2021-06-09 02:52:35 +0000 [info]: adding match pattern="sample" type="stdout"
2021-06-09 02:52:35 +0000 [info]: adding source type="sample"
2021-06-09 02:52:35 +0000 [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2021-06-09 02:52:35 +0000 [warn]: #0 both of Plugin @id and path for <storage> are not specified. Using on-memory store.
2021-06-09 02:52:35 +0000 [warn]: #0 define <match fluent.**> to capture fluentd logs in top level is deprecated. Use <label @FLUENT_LOG> instead
2021-06-09 02:52:35 +0000 [info]: #0 starting fluentd worker pid=16 ppid=7 worker=0
2021-06-09 02:52:35 +0000 [info]: #0 fluentd worker is now running worker=0
2021-06-09 02:52:35 +0000 [warn]: #0 no patterns matched tag="fluent.info"
2021-06-09 02:52:35 +0000 [warn]: #0 no patterns matched tag="fluent.info"
2021-06-09 02:52:36.048169263 +0000 sample: {"message":"sample","loaded":["/usr/local/bundle/gems/resolv-0.2.1/lib/resolv.rb"]}
2021-06-09 02:52:37.049527384 +0000 sample: {"message":"sample","loaded":["/usr/local/bundle/gems/resolv-0.2.1/lib/resolv.rb"]}
2021-06-09 02:52:38.050816670 +0000 sample: {"message":"sample","loaded":["/usr/local/bundle/gems/resolv-0.2.1/lib/resolv.rb"]}
2021-06-09 02:52:39.052066477 +0000 sample: {"message":"sample","loaded":["/usr/local/bundle/gems/resolv-0.2.1/lib/resolv.rb"]}
2021-06-09 02:52:40.053464464 +0000 sample: {"message":"sample","loaded":["/usr/local/bundle/gems/resolv-0.2.1/lib/resolv.rb"]}
2021-06-09 02:52:41.054786553 +0000 sample: {"message":"sample","loaded":["/usr/local/bundle/gems/resolv-0.2.1/lib/resolv.rb"]}
^C2021-06-09 02:52:41 +0000 [info]: Received graceful stop
```
