### PR TITLE
Skip to check signed tini binary instruction

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -141,11 +141,12 @@ RUN apt-get update \
 <% else %>
  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch" \
- && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \
- && export GNUPGHOME="$(mktemp -d)" \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
- && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
- && rm -r /usr/local/bin/tini.asc \
+# NOTE: sks-keyservers is not available anymore, update when https://github.com/krallin/tini/issues/184 was fixed
+# && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \
+# && export GNUPGHOME="$(mktemp -d)" \
+# && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+# && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
+# && rm -r /usr/local/bin/tini.asc \
  && chmod +x /usr/local/bin/tini \
  && tini -h \
 <% if fluentd_ver.start_with?('1') %>

--- a/v1.13/arm64/debian/Dockerfile
+++ b/v1.13/arm64/debian/Dockerfile
@@ -39,11 +39,12 @@ RUN apt-get update \
  && gem install fluentd -v 1.13.0 \
  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch" \
- && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \
- && export GNUPGHOME="$(mktemp -d)" \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
- && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
- && rm -r /usr/local/bin/tini.asc \
+# NOTE: sks-keyservers is not available anymore, update when https://github.com/krallin/tini/issues/184 was fixed
+# && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \
+# && export GNUPGHOME="$(mktemp -d)" \
+# && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+# && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
+# && rm -r /usr/local/bin/tini.asc \
  && chmod +x /usr/local/bin/tini \
  && tini -h \
  && wget -O /tmp/jemalloc-4.5.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/4.5.0/jemalloc-4.5.0.tar.bz2 \

--- a/v1.13/armhf/debian/Dockerfile
+++ b/v1.13/armhf/debian/Dockerfile
@@ -39,11 +39,12 @@ RUN apt-get update \
  && gem install fluentd -v 1.13.0 \
  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch" \
- && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \
- && export GNUPGHOME="$(mktemp -d)" \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
- && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
- && rm -r /usr/local/bin/tini.asc \
+# NOTE: sks-keyservers is not available anymore, update when https://github.com/krallin/tini/issues/184 was fixed
+# && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \
+# && export GNUPGHOME="$(mktemp -d)" \
+# && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+# && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
+# && rm -r /usr/local/bin/tini.asc \
  && chmod +x /usr/local/bin/tini \
  && tini -h \
  && wget -O /tmp/jemalloc-4.5.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/4.5.0/jemalloc-4.5.0.tar.bz2 \

--- a/v1.13/debian/Dockerfile
+++ b/v1.13/debian/Dockerfile
@@ -28,11 +28,12 @@ RUN apt-get update \
  && gem install fluentd -v 1.13.0 \
  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch" \
- && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \
- && export GNUPGHOME="$(mktemp -d)" \
- && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
- && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
- && rm -r /usr/local/bin/tini.asc \
+# NOTE: sks-keyservers is not available anymore, update when https://github.com/krallin/tini/issues/184 was fixed
+# && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \
+# && export GNUPGHOME="$(mktemp -d)" \
+# && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
+# && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
+# && rm -r /usr/local/bin/tini.asc \
  && chmod +x /usr/local/bin/tini \
  && tini -h \
  && wget -O /tmp/jemalloc-4.5.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/4.5.0/jemalloc-4.5.0.tar.bz2 \


### PR DESCRIPTION
sks-keyservers is not available anymore, so
need to wait for upstream updates install instructions.
