### PR TITLE
fix entrypoint.sh to detect the --config and --plugin options

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -211,7 +211,7 @@ ENV RUBYLIB="/usr/local/bundle/gems/resolv-0.2.1/lib"
 EXPOSE 24224 5140
 
 <% if is_windows %>
-ENTRYPOINT ["cmd", "/k", "fluentd", "-c", "C:\\fluent\\conf\\fluent.conf"]
+ENTRYPOINT ["cmd", "/k", "fluentd", "--config", "C:\\fluent\\conf\\fluent.conf"]
 <% else %>
 USER fluent
 ENTRYPOINT ["tini",  "--", "/bin/entrypoint.sh"]

--- a/entrypoint.sh.erb
+++ b/entrypoint.sh.erb
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.12/alpine/entrypoint.sh
+++ b/v1.12/alpine/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.12/arm64/debian/entrypoint.sh
+++ b/v1.12/arm64/debian/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.12/armhf/debian/entrypoint.sh
+++ b/v1.12/armhf/debian/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.12/debian/entrypoint.sh
+++ b/v1.12/debian/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.12/windows-2004/Dockerfile
+++ b/v1.12/windows-2004/Dockerfile
@@ -35,4 +35,4 @@ ENV FLUENTD_CONF="fluent.conf"
 
 EXPOSE 24224 5140
 
-ENTRYPOINT ["cmd", "/k", "fluentd", "-c", "C:\\fluent\\conf\\fluent.conf"]
+ENTRYPOINT ["cmd", "/k", "fluentd", "--config", "C:\\fluent\\conf\\fluent.conf"]

--- a/v1.12/windows-2004/entrypoint.sh
+++ b/v1.12/windows-2004/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.12/windows-20H2/Dockerfile
+++ b/v1.12/windows-20H2/Dockerfile
@@ -35,4 +35,4 @@ ENV FLUENTD_CONF="fluent.conf"
 
 EXPOSE 24224 5140
 
-ENTRYPOINT ["cmd", "/k", "fluentd", "-c", "C:\\fluent\\conf\\fluent.conf"]
+ENTRYPOINT ["cmd", "/k", "fluentd", "--config", "C:\\fluent\\conf\\fluent.conf"]

--- a/v1.12/windows-20H2/entrypoint.sh
+++ b/v1.12/windows-20H2/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.12/windows-ltsc2019/Dockerfile
+++ b/v1.12/windows-ltsc2019/Dockerfile
@@ -35,4 +35,4 @@ ENV FLUENTD_CONF="fluent.conf"
 
 EXPOSE 24224 5140
 
-ENTRYPOINT ["cmd", "/k", "fluentd", "-c", "C:\\fluent\\conf\\fluent.conf"]
+ENTRYPOINT ["cmd", "/k", "fluentd", "--config", "C:\\fluent\\conf\\fluent.conf"]

--- a/v1.12/windows-ltsc2019/entrypoint.sh
+++ b/v1.12/windows-ltsc2019/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.13/alpine/entrypoint.sh
+++ b/v1.13/alpine/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.13/arm64/debian/entrypoint.sh
+++ b/v1.13/arm64/debian/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.13/armhf/debian/entrypoint.sh
+++ b/v1.13/armhf/debian/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.13/debian/entrypoint.sh
+++ b/v1.13/debian/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.13/windows-2004/Dockerfile
+++ b/v1.13/windows-2004/Dockerfile
@@ -36,4 +36,4 @@ ENV FLUENTD_CONF="fluent.conf"
 
 EXPOSE 24224 5140
 
-ENTRYPOINT ["cmd", "/k", "fluentd", "-c", "C:\\fluent\\conf\\fluent.conf"]
+ENTRYPOINT ["cmd", "/k", "fluentd", "--config", "C:\\fluent\\conf\\fluent.conf"]

--- a/v1.13/windows-2004/entrypoint.sh
+++ b/v1.13/windows-2004/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.13/windows-20H2/Dockerfile
+++ b/v1.13/windows-20H2/Dockerfile
@@ -36,4 +36,4 @@ ENV FLUENTD_CONF="fluent.conf"
 
 EXPOSE 24224 5140
 
-ENTRYPOINT ["cmd", "/k", "fluentd", "-c", "C:\\fluent\\conf\\fluent.conf"]
+ENTRYPOINT ["cmd", "/k", "fluentd", "--config", "C:\\fluent\\conf\\fluent.conf"]

--- a/v1.13/windows-20H2/entrypoint.sh
+++ b/v1.13/windows-20H2/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 

--- a/v1.13/windows-ltsc2019/Dockerfile
+++ b/v1.13/windows-ltsc2019/Dockerfile
@@ -36,4 +36,4 @@ ENV FLUENTD_CONF="fluent.conf"
 
 EXPOSE 24224 5140
 
-ENTRYPOINT ["cmd", "/k", "fluentd", "-c", "C:\\fluent\\conf\\fluent.conf"]
+ENTRYPOINT ["cmd", "/k", "fluentd", "--config", "C:\\fluent\\conf\\fluent.conf"]

--- a/v1.13/windows-ltsc2019/entrypoint.sh
+++ b/v1.13/windows-ltsc2019/entrypoint.sh
@@ -16,12 +16,12 @@ fi
 
 # If user does not supply config file or plugins, use the default
 if [ "$1" = "fluentd" ]; then
-    if ! echo $@ | grep ' \-c' ; then
-       set -- "$@" -c /fluentd/etc/${FLUENTD_CONF}
+    if ! echo $@ | grep -e ' \-c' -e ' \-\-config' ; then
+       set -- "$@" --config /fluentd/etc/${FLUENTD_CONF}
     fi
 
-    if ! echo $@ | grep ' \-p' ; then
-       set -- "$@" -p /fluentd/plugins
+    if ! echo $@ | grep -e ' \-p' -e ' \-\-plugin' ; then
+       set -- "$@" --plugin /fluentd/plugins
     fi
 fi
 


### PR DESCRIPTION
If we set config and plugin in long options (`--config` and `--plugin`),
entrypoint.sh still append the `-c` and `-p` options with default value to the Fluentd command.

for example, I ran a fluentd container below:

```bash
docker container run fluent/fluentd:v1.12-1 fluentd \
    --config /fluentd/etc/my-fluent.conf \
    --plugin /fluentd/my-plugins
```

the entrypoint.sh will append the default options to the command and overrided my options:

```bash
fluentd \
    --config /fluentd/etc/my-fluent.conf \
    --plugin /fluentd/my-plugins \
    -c /fluentd/etc/fluent.conf \
    -p /fluentd/plugins
```

I also confirmed the --config and --plugin options are supported
since Fluentd v0.9.0 and v1.0, the changes should be compatible safety.

- https://github.com/fluent/fluentd/blob/v0.9.0/lib/fluent/command/fluentd.rb#L32-L38
- https://github.com/fluent/fluentd/blob/v1.0.0/lib/fluent/command/fluentd.rb#L35-L41

References:

- https://docs.fluentd.org/deployment/command-line-option#fluentd