### PR TITLE
Apply resolv patch only for alpine 3.13 image

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -133,6 +133,9 @@ RUN apt-get update \
  && gem install fluentd -v <%= fluentd_ver %> \
 <% if is_alpine %>
  && gem install bigdecimal -v 1.4.4 \
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# This hack is needed for Ruby 2.6.7, 2.7.3 and 3.0.1. (alpine image is still kept on 2.7.3)
+ && gem install resolv -v 0.2.1 \
  && apk del .build-deps \
 <% else %>
  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
@@ -191,6 +194,10 @@ ENV FLUENTD_CONF="fluent.conf"
 <% if not is_windows %>
 <% if is_alpine %>
 ENV LD_PRELOAD=""
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# Forcing to load specific version of resolv (instead of bundled by default) is needed for Ruby 2.6.7, 2.7.3 and 3.0.1.
+# alpine image is still kept on 2.7.3. See https://pkgs.alpinelinux.org/packages?name=ruby&branch=v3.13
+ENV RUBYLIB="/usr/lib/ruby/gems/2.7.0/gems/resolv-0.2.1/lib"
 <% else %>
 ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
 <% end %>

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 
 IMAGE_NAME := fluent/fluentd
 X86_IMAGES := \
-	v1.13/alpine:v1.13.3-1.0,v1.13-1,edge \
+	v1.13/alpine:v1.13.3-1.1,v1.13-1,edge \
 	v1.13/debian:v1.13.3-debian-1.0,v1.13-debian-1,edge-debian
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 

--- a/v1.13/alpine/Dockerfile
+++ b/v1.13/alpine/Dockerfile
@@ -23,6 +23,9 @@ RUN apk update \
  && gem install ext_monitor -v 0.1.2 \
  && gem install fluentd -v 1.13.3 \
  && gem install bigdecimal -v 1.4.4 \
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# This hack is needed for Ruby 2.6.7, 2.7.3 and 3.0.1. (alpine image is still kept on 2.7.3)
+ && gem install resolv -v 0.2.1 \
  && apk del .build-deps \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /usr/lib/ruby/gems/2.*/gems/fluentd-*/test
 
@@ -41,6 +44,10 @@ COPY entrypoint.sh /bin/
 ENV FLUENTD_CONF="fluent.conf"
 
 ENV LD_PRELOAD=""
+# NOTE: resolv v0.2.1 includes the fix for CPU spike issue due to DNS resolver.
+# Forcing to load specific version of resolv (instead of bundled by default) is needed for Ruby 2.6.7, 2.7.3 and 3.0.1.
+# alpine image is still kept on 2.7.3. See https://pkgs.alpinelinux.org/packages?name=ruby&branch=v3.13
+ENV RUBYLIB="/usr/lib/ruby/gems/2.7.0/gems/resolv-0.2.1/lib"
 EXPOSE 24224 5140
 
 USER fluent

--- a/v1.13/alpine/hooks/post_push
+++ b/v1.13/alpine/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.13.3-1.0,v1.13-1,edge}; do
+for tag in {v1.13.3-1.1,v1.13-1,edge}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done


### PR DESCRIPTION
Close #288

It still uses Ruby 2.7.3. It is an affected version of Ruby.

See https://pkgs.alpinelinux.org/packages?name=ruby&branch=v3.13

