### PR TITLE
alpine: debian: Bump up the version to v1.14-1.1 to update base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,17 @@
 
 IMAGE_NAME := fluent/fluentd
 X86_IMAGES := \
-	v1.14/alpine:v1.14.0-1.0,v1.14-1,edge \
-	v1.14/debian:v1.14.0-debian-1.0,v1.14-debian-1,edge-debian
+	v1.14/alpine:v1.14.0-1.1,v1.14-1,edge \
+	v1.14/debian:v1.14.0-debian-1.1,v1.14-debian-1,edge-debian
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 
 # Define images for running on ARM platforms
 ARM_IMAGES := \
-	v1.14/armhf/debian:v1.14.0-debian-armhf-1.0,v1.14-debian-armhf-1,edge-debian-armhf \
+	v1.14/armhf/debian:v1.14.0-debian-armhf-1.1,v1.14-debian-armhf-1,edge-debian-armhf \
 
 # Define images for running on ARM64 platforms
 ARM64_IMAGES := \
-	v1.14/arm64/debian:v1.14.0-debian-arm64-1.0,v1.14-debian-arm64-1,edge-debian-arm64 \
+	v1.14/arm64/debian:v1.14.0-debian-arm64-1.1,v1.14-debian-arm64-1,edge-debian-arm64 \
 
 WINDOWS_IMAGES := \
 	v1.14/windows-ltsc2019:v1.14.0-windows-ltsc2019-1.0,v1.14-windows-ltsc2019-1 \

--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ These tags have image version postfix. This updates many places so we need feedb
 
 Current images use fluentd v1 series.
 
-- `v1.13.0-1.0`, `v1.13-1`, `edge`
-  [(v1.13/alpine/Dockerfile)][fluentd-1-alpine]
-- `v1.13.0-debian-1.0`, `v1.13-debian-1`, `edge-debian`
-  [(v1.13/debian/Dockerfile)][fluentd-1-debian]
-- `v1.13.0-debian-arm64-1.0`, `v1.13-debian-arm64-1`, `edge-debian-arm64`
-  [(v1.13/arm64/debian/Dockerfile)][fluentd-1-debian-arm64]
-- `v1.13.0-debian-armhf-1.0`, `v1.13-debian-armhf-1`, `edge-debian-armhf`
-  [(v1.13/armhf/debian/Dockerfile)][fluentd-1-debian-armhf]
-- `v1.13.0-windows-ltsc2019-1.0`, `v1.13-windows-ltsc2019-1`
-  [(v1.13/windows-ltsc2019/Dockerfile)][fluentd-1-ltsc2019-windows]
-- `v1.13.0-windows-2004-1.0`, `v1.13-windows-2004-1`
-  [(v1.13/windows-2004/Dockerfile)][fluentd-1-2004-windows]
-- `v1.13.0-windows-20H2-1.0`, `v1.13-windows-20H2-1`
-  [(v1.13/windows-20H2/Dockerfile)][fluentd-1-20H2-windows]
+- `v1.14.0-1.0`, `v1.14-1`, `edge`
+  [(v1.14/alpine/Dockerfile)][fluentd-1-alpine]
+- `v1.14.0-debian-1.0`, `v1.14-debian-1`, `edge-debian`
+  [(v1.14/debian/Dockerfile)][fluentd-1-debian]
+- `v1.14.0-debian-arm64-1.0`, `v1.14-debian-arm64-1`, `edge-debian-arm64`
+  [(v1.14/arm64/debian/Dockerfile)][fluentd-1-debian-arm64]
+- `v1.14.0-debian-armhf-1.0`, `v1.14-debian-armhf-1`, `edge-debian-armhf`
+  [(v1.14/armhf/debian/Dockerfile)][fluentd-1-debian-armhf]
+- `v1.14.0-windows-ltsc2019-1.0`, `v1.14-windows-ltsc2019-1`
+  [(v1.14/windows-ltsc2019/Dockerfile)][fluentd-1-ltsc2019-windows]
+- `v1.14.0-windows-2004-1.0`, `v1.14-windows-2004-1`
+  [(v1.14/windows-2004/Dockerfile)][fluentd-1-2004-windows]
+- `v1.14.0-windows-20H2-1.0`, `v1.14-windows-20H2-1`
+  [(v1.14/windows-20H2/Dockerfile)][fluentd-1-20H2-windows]
 
 ### Old v1.4 images
 
@@ -224,7 +224,7 @@ To add plugins, edit `Dockerfile` as following:
 #### Alpine version
 
 ```Dockerfile
-FROM fluent/fluentd:v1.13-1
+FROM fluent/fluentd:v1.14-1
 
 # Use root account to use apk
 USER root
@@ -247,7 +247,7 @@ USER fluent
 #### Debian version
 
 ```Dockerfile
-FROM fluent/fluentd:v1.13-debian-1
+FROM fluent/fluentd:v1.14-debian-1
 
 # Use root account to use apt
 USER root
@@ -390,10 +390,10 @@ through a [GitHub issue](https://github.com/fluent/fluentd-docker-image/issues).
 [fluentd-1-4-debian]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.4/debian/Dockerfile
 [fluentd-1-4-debian-onbuild]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.4/debian-onbuild/Dockerfile
 [fluentd-1-4-windows]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.4/windows/Dockerfile
-[fluentd-1-alpine]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.13/alpine/Dockerfile
-[fluentd-1-debian]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.13/debian/Dockerfile
-[fluentd-1-debian-arm64]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.13/arm64/debian/Dockerfile
-[fluentd-1-debian-armhf]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.13/armhf/debian/Dockerfile
-[fluentd-1-ltsc2019-windows]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.13/windows-ltsc2019/Dockerfile
-[fluentd-1-2004-windows]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.13/windows-2004/Dockerfile
-[fluentd-1-20H2-windows]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.13/windows-20H2/Dockerfile
+[fluentd-1-alpine]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.14/alpine/Dockerfile
+[fluentd-1-debian]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.14/debian/Dockerfile
+[fluentd-1-debian-arm64]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.14/arm64/debian/Dockerfile
+[fluentd-1-debian-armhf]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.14/armhf/debian/Dockerfile
+[fluentd-1-ltsc2019-windows]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.14/windows-ltsc2019/Dockerfile
+[fluentd-1-2004-windows]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.14/windows-2004/Dockerfile
+[fluentd-1-20H2-windows]: https://github.com/fluent/fluentd-docker-image/blob/master/v1.14/windows-20H2/Dockerfile

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ These tags have image version postfix. This updates many places so we need feedb
 
 Current images use fluentd v1 series.
 
-- `v1.14.0-1.0`, `v1.14-1`, `edge`
+- `v1.14.0-1.1`, `v1.14-1`, `edge`
   [(v1.14/alpine/Dockerfile)][fluentd-1-alpine]
-- `v1.14.0-debian-1.0`, `v1.14-debian-1`, `edge-debian`
+- `v1.14.0-debian-1.1`, `v1.14-debian-1`, `edge-debian`
   [(v1.14/debian/Dockerfile)][fluentd-1-debian]
-- `v1.14.0-debian-arm64-1.0`, `v1.14-debian-arm64-1`, `edge-debian-arm64`
+- `v1.14.0-debian-arm64-1.1`, `v1.14-debian-arm64-1`, `edge-debian-arm64`
   [(v1.14/arm64/debian/Dockerfile)][fluentd-1-debian-arm64]
-- `v1.14.0-debian-armhf-1.0`, `v1.14-debian-armhf-1`, `edge-debian-armhf`
+- `v1.14.0-debian-armhf-1.1`, `v1.14-debian-armhf-1`, `edge-debian-armhf`
   [(v1.14/armhf/debian/Dockerfile)][fluentd-1-debian-armhf]
 - `v1.14.0-windows-ltsc2019-1.0`, `v1.14-windows-ltsc2019-1`
   [(v1.14/windows-ltsc2019/Dockerfile)][fluentd-1-ltsc2019-windows]

--- a/v1.14/alpine/hooks/post_push
+++ b/v1.14/alpine/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.14.0-1.0,v1.14-1,edge}; do
+for tag in {v1.14.0-1.1,v1.14-1,edge}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.14/arm64/debian/hooks/post_push
+++ b/v1.14/arm64/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.14.0-debian-arm64-1.0,v1.14-debian-arm64-1,edge-debian-arm64}; do
+for tag in {v1.14.0-debian-arm64-1.1,v1.14-debian-arm64-1,edge-debian-arm64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.14/armhf/debian/hooks/post_push
+++ b/v1.14/armhf/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.14.0-debian-armhf-1.0,v1.14-debian-armhf-1,edge-debian-armhf}; do
+for tag in {v1.14.0-debian-armhf-1.1,v1.14-debian-armhf-1,edge-debian-armhf}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.14/debian/hooks/post_push
+++ b/v1.14/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.14.0-debian-1.0,v1.14-debian-1,edge-debian}; do
+for tag in {v1.14.0-debian-1.1,v1.14-debian-1,edge-debian}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done


### PR DESCRIPTION
Fix following vulnerabilities:
* https://nvd.nist.gov/vuln/detail/CVE-2021-36159
* https://nvd.nist.gov/vuln/detail/CVE-2021-3711
* https://nvd.nist.gov/vuln/detail/CVE-2021-3712
 
See #292