### PR TITLE
Set fluent group correctly for alpine image

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -164,7 +164,7 @@ RUN apt-get update \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /usr/lib/ruby/gems/2.*/gems/fluentd-*/test
 
 <% if is_alpine %>
-RUN addgroup -S fluent && adduser -S -g fluent fluent \
+RUN addgroup -S fluent && adduser -S -G fluent fluent \
     # for log storage (maybe shared with host)
     && mkdir -p /fluentd/log \
     # configuration/plugins path (default: copied from .)


### PR DESCRIPTION
In the previous alpine image, fluent group is not set correctly.
It should use -G for it.

  % docker run -u root --rm -it fluent/fluentd:v1.14-1  /bin/sh
  / # id fluent
  uid=100(fluent) gid=65533(nogroup) groups=65533(nogroup),65533(nogroup)
  / # adduser -S -g fluent foo
  / # id foo
  uid=101(foo) gid=65533(nogroup) groups=65533(nogroup),65533(nogroup)
  / # adduser -S -G fluent bar
  / # id bar
  uid=102(bar) gid=101(fluent) groups=101(fluent),101(fluent)

Follow up #245

