### PR TITLE
arm64: fix qemu SEGV during build process

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -35,9 +35,9 @@ COPY --from=builder /go/qemu-arm-static /usr/bin/
 # To set multiarch build for Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM arm64v8/ruby:2.7-slim-bullseye
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/v1.14/arm64/debian/Dockerfile
+++ b/v1.14/arm64/debian/Dockerfile
@@ -4,9 +4,9 @@
 # To set multiarch build for Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM arm64v8/ruby:2.7-slim-bullseye
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/


### PR DESCRIPTION
Docker hub automated build fails with bullseye.

See https://hub.docker.com/repository/registry-1.docker.io/fluent/fluentd/builds/1270ea66-23c7-4fb6-b113-9e8e4a59357b

It is caused by qemu-user-static that host(groovy) still contains a bug that crashes
arm64 Debian Bullseye guests.

   #14 120.8 Setting up g++ (4:10.2.1-1) ...
   #14 121.1 update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
   #14 121.1 Setting up gnupg (2.2.27-2) ...
   #14 121.1 Processing triggers for libc-bin (2.31-13+deb11u2) ...
   #14 121.2 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
   #14 121.5 Segmentation fault (core dumped)
   #14 121.6 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
   #14 121.8 Segmentation fault (core dumped)
   #14 121.8 dpkg: error processing package libc-bin (--configure):
   #14 121.8 installed libc-bin package post-installation script subprocess returned error exit status 139
   #14 121.8 Errors were encountered while processing:
   #14 121.8 libc-bin
   #14 121.9 E: Sub-process /usr/bin/dpkg returned an error code (1)

As a workaround, it use a newer qemu.

Signed-off-by: Kentaro Hayashi <hayashi@clear-code.com>