### PR TITLE
Unify multiarch tags

### DIFF
--- a/post_push.erb
+++ b/post_push.erb
@@ -7,9 +7,26 @@ set -e
 # Parse image name for repo name
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
-
+<% if image_tags.include?("debian") %>
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+<% end %>
 # Tag and push image for each additional tag
 for tag in {<%= image_tags %>}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+<% if image_tags.include?("debian") %>
+  archTag=${tag/amd64/ARCH}
+  archTag=${archTag/arm64/ARCH}
+  archTag=${archTag/armhf/ARCH}
+  noArchTag=${tag/-amd64/}
+  noArchTag=${noArchTag/-arm64/}
+  noArchTag=${noArchTag/-armhf/}
+  # Note: this will fail until three of the amd64, armv7, and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm/v7,linux/arm64 \
+      --template ${repoName}:${archTag} \
+      --target ${repoName}:${noArchTag} || true
+<% end %>
 done

--- a/v1.15/alpine/hooks/post_push
+++ b/v1.15/alpine/hooks/post_push
@@ -12,4 +12,5 @@ repoName=${IMAGE_NAME:0:tagStart-1}
 for tag in {v1.15.0-1.0,v1.15-1,edge}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+
 done

--- a/v1.15/arm64/debian/hooks/post_push
+++ b/v1.15/arm64/debian/hooks/post_push
@@ -8,8 +8,25 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
 # Tag and push image for each additional tag
 for tag in {v1.15.0-debian-arm64-1.0,v1.15-debian-arm64-1,edge-debian-arm64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+
+  archTag=${tag/amd64/ARCH}
+  archTag=${archTag/arm64/ARCH}
+  archTag=${archTag/armhf/ARCH}
+  noArchTag=${tag/-amd64/}
+  noArchTag=${noArchTag/-arm64/}
+  noArchTag=${noArchTag/-armhf/}
+  # Note: this will fail until three of the amd64, armv7, and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm/v7,linux/arm64 \
+      --template ${repoName}:${archTag} \
+      --target ${repoName}:${noArchTag} || true
+
 done

--- a/v1.15/armhf/debian/hooks/post_push
+++ b/v1.15/armhf/debian/hooks/post_push
@@ -8,8 +8,25 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
 # Tag and push image for each additional tag
 for tag in {v1.15.0-debian-armhf-1.0,v1.15-debian-armhf-1,edge-debian-armhf}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+
+  archTag=${tag/amd64/ARCH}
+  archTag=${archTag/arm64/ARCH}
+  archTag=${archTag/armhf/ARCH}
+  noArchTag=${tag/-amd64/}
+  noArchTag=${noArchTag/-arm64/}
+  noArchTag=${noArchTag/-armhf/}
+  # Note: this will fail until three of the amd64, armv7, and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm/v7,linux/arm64 \
+      --template ${repoName}:${archTag} \
+      --target ${repoName}:${noArchTag} || true
+
 done

--- a/v1.15/debian/hooks/post_push
+++ b/v1.15/debian/hooks/post_push
@@ -8,8 +8,25 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
 # Tag and push image for each additional tag
 for tag in {v1.15.0-debian-1.0,v1.15-debian-1,edge-debian}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+
+  archTag=${tag/amd64/ARCH}
+  archTag=${archTag/arm64/ARCH}
+  archTag=${archTag/armhf/ARCH}
+  noArchTag=${tag/-amd64/}
+  noArchTag=${noArchTag/-arm64/}
+  noArchTag=${noArchTag/-armhf/}
+  # Note: this will fail until three of the amd64, armv7, and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm/v7,linux/arm64 \
+      --template ${repoName}:${archTag} \
+      --target ${repoName}:${noArchTag} || true
+
 done

--- a/v1.15/windows-20H2/hooks/post_push
+++ b/v1.15/windows-20H2/hooks/post_push
@@ -12,4 +12,5 @@ repoName=${IMAGE_NAME:0:tagStart-1}
 for tag in {v1.15.0-windows-20H2-1.0,v1.15-windows-20H2-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+
 done

--- a/v1.15/windows-ltsc2019/hooks/post_push
+++ b/v1.15/windows-ltsc2019/hooks/post_push
@@ -12,4 +12,5 @@ repoName=${IMAGE_NAME:0:tagStart-1}
 for tag in {v1.15.0-windows-ltsc2019-1.0,v1.15-windows-ltsc2019-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+
 done

--- a/v1.15/windows-ltsc2022/hooks/post_push
+++ b/v1.15/windows-ltsc2022/hooks/post_push
@@ -12,4 +12,5 @@ repoName=${IMAGE_NAME:0:tagStart-1}
 for tag in {v1.15.0-windows-ltsc2022-1.0,v1.15-windows-ltsc2022-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+
 done


### PR DESCRIPTION
Like as https://github.com/fluent/fluentd-kubernetes-daemonset/pull/566, we should provide `1.x-debian-1.x` tag as multi-arch images instead of amd64(x86_64) images.

In recent days, non-x86_64 machine is more and more important such as Apple Silicon (Apple M1 and will be M2) based machines.

Sometimes, our provided built tags will suffer for users why the image won't be runnable for such environment.