### PR TITLE
Bump up the revision to update base image, Ruby and gems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,22 +13,22 @@
 
 IMAGE_NAME := fluent/fluentd
 X86_IMAGES := \
-	v1.14/alpine:v1.14.6-1.1,v1.14-1,edge \
-	v1.14/debian:v1.14.6-debian-1.0,v1.14-debian-1,edge-debian
+	v1.14/alpine:v1.14.6-1.2,v1.14-1,edge \
+	v1.14/debian:v1.14.6-debian-1.1,v1.14-debian-1,edge-debian
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 
 # Define images for running on ARM platforms
 ARM_IMAGES := \
-	v1.14/armhf/debian:v1.14.6-debian-armhf-1.0,v1.14-debian-armhf-1,edge-debian-armhf \
+	v1.14/armhf/debian:v1.14.6-debian-armhf-1.1,v1.14-debian-armhf-1,edge-debian-armhf \
 
 # Define images for running on ARM64 platforms
 ARM64_IMAGES := \
-	v1.14/arm64/debian:v1.14.6-debian-arm64-1.0,v1.14-debian-arm64-1,edge-debian-arm64 \
+	v1.14/arm64/debian:v1.14.6-debian-arm64-1.1,v1.14-debian-arm64-1,edge-debian-arm64 \
 
 WINDOWS_IMAGES := \
-	v1.14/windows-ltsc2019:v1.14.6-windows-ltsc2019-1.0,v1.14-windows-ltsc2019-1 \
-	v1.14/windows-20H2:v1.14.6-windows-20H2-1.0,v1.14-windows-20H2-1 \
-	v1.14/windows-ltsc2022:v1.14.6-windows-ltsc2022-1.0,v1.14-windows-ltsc2022-1
+	v1.14/windows-ltsc2019:v1.14.6-windows-ltsc2019-1.1,v1.14-windows-ltsc2019-1 \
+	v1.14/windows-20H2:v1.14.6-windows-20H2-1.1,v1.14-windows-20H2-1 \
+	v1.14/windows-ltsc2022:v1.14.6-windows-ltsc2022-1.1,v1.14-windows-ltsc2022-1
 
 ALL_IMAGES := $(X86_IMAGES) $(ARM_IMAGES) $(ARM64_IMAGES) $(WINDOWS_IMAGES)
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ These tags have image version postfix. This updates many places so we need feedb
 
 Current images use fluentd v1 series.
 
-- `v1.14.6-1.1`, `v1.14-1`, `edge`
+- `v1.14.6-1.2`, `v1.14-1`, `edge`
   [(v1.14/alpine/Dockerfile)][fluentd-1-alpine]
-- `v1.14.6-debian-1.0`, `v1.14-debian-1`, `edge-debian`
+- `v1.14.6-debian-1.1`, `v1.14-debian-1`, `edge-debian`
   [(v1.14/debian/Dockerfile)][fluentd-1-debian]
-- `v1.14.6-debian-arm64-1.0`, `v1.14-debian-arm64-1`, `edge-debian-arm64`
+- `v1.14.6-debian-arm64-1.1`, `v1.14-debian-arm64-1`, `edge-debian-arm64`
   [(v1.14/arm64/debian/Dockerfile)][fluentd-1-debian-arm64]
-- `v1.14.6-debian-armhf-1.0`, `v1.14-debian-armhf-1`, `edge-debian-armhf`
+- `v1.14.6-debian-armhf-1.1`, `v1.14-debian-armhf-1`, `edge-debian-armhf`
   [(v1.14/armhf/debian/Dockerfile)][fluentd-1-debian-armhf]
-- `v1.14.6-windows-ltsc2019-1.0`, `v1.14-windows-ltsc2019-1`
+- `v1.14.6-windows-ltsc2019-1.1`, `v1.14-windows-ltsc2019-1`
   [(v1.14/windows-ltsc2019/Dockerfile)][fluentd-1-ltsc2019-windows]
-- `v1.14.6-windows-20H2-1.0`, `v1.14-windows-20H2-1`
+- `v1.14.6-windows-20H2-1.1`, `v1.14-windows-20H2-1`
   [(v1.14/windows-20H2/Dockerfile)][fluentd-1-20H2-windows]
 
 ### Old v1.4 images

--- a/v1.14/alpine/hooks/post_push
+++ b/v1.14/alpine/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.14.6-1.1,v1.14-1,edge}; do
+for tag in {v1.14.6-1.2,v1.14-1,edge}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.14/arm64/debian/hooks/post_push
+++ b/v1.14/arm64/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.14.6-debian-arm64-1.0,v1.14-debian-arm64-1,edge-debian-arm64}; do
+for tag in {v1.14.6-debian-arm64-1.1,v1.14-debian-arm64-1,edge-debian-arm64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.14/armhf/debian/hooks/post_push
+++ b/v1.14/armhf/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.14.6-debian-armhf-1.0,v1.14-debian-armhf-1,edge-debian-armhf}; do
+for tag in {v1.14.6-debian-armhf-1.1,v1.14-debian-armhf-1,edge-debian-armhf}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.14/debian/hooks/post_push
+++ b/v1.14/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.14.6-debian-1.0,v1.14-debian-1,edge-debian}; do
+for tag in {v1.14.6-debian-1.1,v1.14-debian-1,edge-debian}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.14/windows-20H2/hooks/post_push
+++ b/v1.14/windows-20H2/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.14.6-windows-20H2-1.0,v1.14-windows-20H2-1}; do
+for tag in {v1.14.6-windows-20H2-1.1,v1.14-windows-20H2-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.14/windows-ltsc2019/hooks/post_push
+++ b/v1.14/windows-ltsc2019/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.14.6-windows-ltsc2019-1.0,v1.14-windows-ltsc2019-1}; do
+for tag in {v1.14.6-windows-ltsc2019-1.1,v1.14-windows-ltsc2019-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/v1.14/windows-ltsc2022/hooks/post_push
+++ b/v1.14/windows-ltsc2022/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.14.6-windows-ltsc2022-1.0,v1.14-windows-ltsc2022-1}; do
+for tag in {v1.14.6-windows-ltsc2022-1.1,v1.14-windows-ltsc2022-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done


### PR DESCRIPTION
Fluentd's version isn't changed: v1.14.6
Just for updating base image, Ruby and gems to suppress some vulnerabilities.

Note that our urgent task is updating fluentd-kubernetes-daemonset to fix https://github.com/fluent/fluentd-kubernetes-daemonset/issues/1361, updating the base image is just a work that accompanies it.