### PR TITLE
Follow up #330 PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 IMAGE_NAME := fluent/fluentd
 X86_IMAGES := \
 	v1.15/alpine:v1.15.0-1.0,v1.15-1,edge \
-	v1.15/debian:v1.15.0-debian-1.0,v1.15-debian-1,edge-debian
+	v1.15/debian:v1.15.0-debian-amd64-1.0,v1.15-debian-amd64-1,edge-debian-amd64
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 
 # Define images for running on ARM platforms

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Current images use fluentd v1 series.
 - `v1.15.0-1.0`, `v1.15-1`, `edge`
   [(v1.15/alpine/Dockerfile)][fluentd-1-alpine]
 - `v1.15.0-debian-1.0`, `v1.15-debian-1`, `edge-debian`
+  (multiarch image)
+- `v1.15.0-debian-amd64-1.0`, `v1.15-debian-amd64-1`, `edge-debian-amd64`
   [(v1.15/debian/Dockerfile)][fluentd-1-debian]
 - `v1.15.0-debian-arm64-1.0`, `v1.15-debian-arm64-1`, `edge-debian-arm64`
   [(v1.15/arm64/debian/Dockerfile)][fluentd-1-debian-arm64]

--- a/v1.15/debian/hooks/post_push
+++ b/v1.15/debian/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image for each additional tag
-for tag in {v1.15.0-debian-1.0,v1.15-debian-1,edge-debian}; do
+for tag in {v1.15.0-debian-amd64-1.0,v1.15-debian-amd64-1,edge-debian-amd64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 


### PR DESCRIPTION
We have to add `amd64` for amd64(x86_64) image.

Sorry, I forgot to add `amd64` suffix changes on #330.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>