### PR TITLE
Stop to use manifest-tool on armhf post_push hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Current images use fluentd v1 series.
 - `v1.15.0-1.0`, `v1.15-1`, `edge`
   [(v1.15/alpine/Dockerfile)][fluentd-1-alpine]
 - `v1.15.0-debian-1.0`, `v1.15-debian-1`, `edge-debian`
-  (multiarch image)
+  (multiarch image for arm64(AArch64) and amd64(x86_64))
 - `v1.15.0-debian-amd64-1.0`, `v1.15-debian-amd64-1`, `edge-debian-amd64`
   [(v1.15/debian/Dockerfile)][fluentd-1-debian]
 - `v1.15.0-debian-arm64-1.0`, `v1.15-debian-arm64-1`, `edge-debian-arm64`

--- a/post_push.erb
+++ b/post_push.erb
@@ -7,7 +7,7 @@ set -e
 # Parse image name for repo name
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
-<% if image_tags.include?("debian") %>
+<% if image_tags.include?("debian-arm64") || image_tags.include?("debian-amd64") %>
 # Download manifest tool
 curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
 chmod +x manifest-tool
@@ -16,16 +16,14 @@ chmod +x manifest-tool
 for tag in {<%= image_tags %>}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
-<% if image_tags.include?("debian") %>
+<% if image_tags.include?("debian-arm64") || image_tags.include?("debian-amd64") %>
   archTag=${tag/amd64/ARCH}
   archTag=${archTag/arm64/ARCH}
-  archTag=${archTag/armhf/ARCH}
   noArchTag=${tag/-amd64/}
   noArchTag=${noArchTag/-arm64/}
-  noArchTag=${noArchTag/-armhf/}
-  # Note: this will fail until three of the amd64, armv7, and arm64 images have been pushed
+  # Note: this will fail until three of the amd64 and arm64 images have been pushed
   ./manifest-tool push from-args \
-      --platforms linux/amd64,linux/arm/v7,linux/arm64 \
+      --platforms linux/amd64,linux/arm64 \
       --template ${repoName}:${archTag} \
       --target ${repoName}:${noArchTag} || true
 <% end %>

--- a/v1.15/arm64/debian/hooks/post_push
+++ b/v1.15/arm64/debian/hooks/post_push
@@ -19,13 +19,11 @@ for tag in {v1.15.0-debian-arm64-1.0,v1.15-debian-arm64-1,edge-debian-arm64}; do
 
   archTag=${tag/amd64/ARCH}
   archTag=${archTag/arm64/ARCH}
-  archTag=${archTag/armhf/ARCH}
   noArchTag=${tag/-amd64/}
   noArchTag=${noArchTag/-arm64/}
-  noArchTag=${noArchTag/-armhf/}
-  # Note: this will fail until three of the amd64, armv7, and arm64 images have been pushed
+  # Note: this will fail until three of the amd64 and arm64 images have been pushed
   ./manifest-tool push from-args \
-      --platforms linux/amd64,linux/arm/v7,linux/arm64 \
+      --platforms linux/amd64,linux/arm64 \
       --template ${repoName}:${archTag} \
       --target ${repoName}:${noArchTag} || true
 

--- a/v1.15/armhf/debian/hooks/post_push
+++ b/v1.15/armhf/debian/hooks/post_push
@@ -8,25 +8,9 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Download manifest tool
-curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
-chmod +x manifest-tool
-
 # Tag and push image for each additional tag
 for tag in {v1.15.0-debian-armhf-1.0,v1.15-debian-armhf-1,edge-debian-armhf}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
-
-  archTag=${tag/amd64/ARCH}
-  archTag=${archTag/arm64/ARCH}
-  archTag=${archTag/armhf/ARCH}
-  noArchTag=${tag/-amd64/}
-  noArchTag=${noArchTag/-arm64/}
-  noArchTag=${noArchTag/-armhf/}
-  # Note: this will fail until three of the amd64, armv7, and arm64 images have been pushed
-  ./manifest-tool push from-args \
-      --platforms linux/amd64,linux/arm/v7,linux/arm64 \
-      --template ${repoName}:${archTag} \
-      --target ${repoName}:${noArchTag} || true
 
 done

--- a/v1.15/debian/hooks/post_push
+++ b/v1.15/debian/hooks/post_push
@@ -19,13 +19,11 @@ for tag in {v1.15.0-debian-amd64-1.0,v1.15-debian-amd64-1,edge-debian-amd64}; do
 
   archTag=${tag/amd64/ARCH}
   archTag=${archTag/arm64/ARCH}
-  archTag=${archTag/armhf/ARCH}
   noArchTag=${tag/-amd64/}
   noArchTag=${noArchTag/-arm64/}
-  noArchTag=${noArchTag/-armhf/}
-  # Note: this will fail until three of the amd64, armv7, and arm64 images have been pushed
+  # Note: this will fail until three of the amd64 and arm64 images have been pushed
   ./manifest-tool push from-args \
-      --platforms linux/amd64,linux/arm/v7,linux/arm64 \
+      --platforms linux/amd64,linux/arm64 \
       --template ${repoName}:${archTag} \
       --target ${repoName}:${noArchTag} || true
 


### PR DESCRIPTION
Not sure why arm/v7 manifest is not found but we can use unifying tags for arm64 and amd64 manifests.

Re-follows up for #330.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>