### PR TITLE
Disable MADV_FREE during jemalloc compilation

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -135,6 +135,8 @@ RUN apt-get update \
  && tini -h \
  && wget -O /tmp/jemalloc-5.3.0.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 \
  && cd /tmp && tar -xjf jemalloc-5.3.0.tar.bz2 && cd jemalloc-5.3.0/ \
+ # Don't use MADV_FREE to reduce memory usage and improve stability
+ # https://github.com/fluent/fluentd-docker-image/pull/350
  && (echo "je_cv_madv_free=no" > config.cache) && ./configure -C && make \
  && mv lib/libjemalloc.so.2 /usr/lib \
  && apt-get purge -y --auto-remove \


### PR DESCRIPTION
madvise with MADV_FREE can result in misleading metrics, as reclaim of those pages happens lazily. There's plenty of examples of projects disabling it for this reason:

- https://github.com/golang/go/issues/42330
- https://github.com/cockroachdb/cockroach/issues/83790

In fact, `jemalloc` has this example in their own [INSTALL.md](https://github.com/jemalloc/jemalloc/blob/dev/INSTALL.md).

We'd like to do the same here in order to ensure process metrics more closely track non-reclaimable anonymous memory.

See our [downstream issue](https://gitlab.com/gitlab-com/gl-infra/scalability/-/issues/2024).