### PR TITLE
Update images to apply Debian 11.6 point release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,16 @@
 IMAGE_NAME := fluent/fluentd
 X86_IMAGES := \
 	v1.15/alpine:v1.15.3-1.0,v1.15-1,edge \
-	v1.15/debian:v1.15.3-debian-amd64-1.0,v1.15-debian-amd64-1,edge-debian-amd64
+	v1.15/debian:v1.15.3-debian-amd64-1.1,v1.15-debian-amd64-1,edge-debian-amd64
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 
 # Define images for running on ARM platforms
 ARM_IMAGES := \
-	v1.15/armhf/debian:v1.15.3-debian-armhf-1.0,v1.15-debian-armhf-1,edge-debian-armhf \
+	v1.15/armhf/debian:v1.15.3-debian-armhf-1.1,v1.15-debian-armhf-1,edge-debian-armhf \
 
 # Define images for running on ARM64 platforms
 ARM64_IMAGES := \
-	v1.15/arm64/debian:v1.15.3-debian-arm64-1.0,v1.15-debian-arm64-1,edge-debian-arm64 \
+	v1.15/arm64/debian:v1.15.3-debian-arm64-1.1,v1.15-debian-arm64-1,edge-debian-arm64 \
 
 WINDOWS_IMAGES := \
 	v1.15/windows-ltsc2019:v1.15.3-windows-ltsc2019-1.0,v1.15-windows-ltsc2019-1 \

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Current images use fluentd v1 series.
 
 - `v1.15.3-1.0`, `v1.15-1`, `edge`
   [(v1.15/alpine/Dockerfile)][fluentd-1-alpine]
-- `v1.15.3-debian-1.0`, `v1.15-debian-1`, `edge-debian`
+- `v1.15.3-debian-1.1`, `v1.15-debian-1`, `edge-debian`
   (multiarch image for arm64(AArch64) and amd64(x86_64))
-- `v1.15.3-debian-amd64-1.0`, `v1.15-debian-amd64-1`, `edge-debian-amd64`
+- `v1.15.3-debian-amd64-1.1`, `v1.15-debian-amd64-1`, `edge-debian-amd64`
   [(v1.15/debian/Dockerfile)][fluentd-1-debian]
-- `v1.15.3-debian-arm64-1.0`, `v1.15-debian-arm64-1`, `edge-debian-arm64`
+- `v1.15.3-debian-arm64-1.1`, `v1.15-debian-arm64-1`, `edge-debian-arm64`
   [(v1.15/arm64/debian/Dockerfile)][fluentd-1-debian-arm64]
-- `v1.15.3-debian-armhf-1.0`, `v1.15-debian-armhf-1`, `edge-debian-armhf`
+- `v1.15.3-debian-armhf-1.1`, `v1.15-debian-armhf-1`, `edge-debian-armhf`
   [(v1.15/armhf/debian/Dockerfile)][fluentd-1-debian-armhf]
 - `v1.15.3-windows-ltsc2019-1.0`, `v1.15-windows-ltsc2019-1`
   [(v1.15/windows-ltsc2019/Dockerfile)][fluentd-1-ltsc2019-windows]

--- a/v1.15/arm64/debian/hooks/post_push
+++ b/v1.15/arm64/debian/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image for each additional tag
-for tag in {v1.15.3-debian-arm64-1.0,v1.15-debian-arm64-1,edge-debian-arm64}; do
+for tag in {v1.15.3-debian-arm64-1.1,v1.15-debian-arm64-1,edge-debian-arm64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 

--- a/v1.15/armhf/debian/hooks/post_push
+++ b/v1.15/armhf/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.15.3-debian-armhf-1.0,v1.15-debian-armhf-1,edge-debian-armhf}; do
+for tag in {v1.15.3-debian-armhf-1.1,v1.15-debian-armhf-1,edge-debian-armhf}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 

--- a/v1.15/debian/hooks/post_push
+++ b/v1.15/debian/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image for each additional tag
-for tag in {v1.15.3-debian-amd64-1.0,v1.15-debian-amd64-1,edge-debian-amd64}; do
+for tag in {v1.15.3-debian-amd64-1.1,v1.15-debian-amd64-1,edge-debian-amd64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 


### PR DESCRIPTION
Debian 11.6 point release was published on Dec 17.
See https://www.debian.org/News/2022/20221217

ruby:3.1-slim-bullseye: Update Dec 22
arm32v7/ruby:3.1-slim-bullseye: Updated Dec 22
arm64v8/ruby:3.1-slim-bullseye: Updated Dec 21