### PR TITLE
Add v1.16.3 images

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -74,7 +74,7 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 
 # NOTE: For avoiding stalling with docker build on windows, we must use latest version of msys2.
 RUN choco install -y ruby --version 3.1.3.1 --params "'/InstallDir:C:\ruby31'" \
-&& choco install -y msys2 --version 20230718.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby31\msys64'"
+&& choco install -y msys2 --version 20231026.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby31\msys64'"
 RUN refreshenv \
 && ridk install 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \

--- a/Makefile
+++ b/Makefile
@@ -13,21 +13,21 @@
 
 IMAGE_NAME := fluent/fluentd
 X86_IMAGES := \
-	v1.16/alpine:v1.16.2-1.1,v1.16-1,edge \
-	v1.16/debian:v1.16.2-debian-amd64-1.1,v1.16-debian-amd64-1,edge-debian-amd64
+	v1.16/alpine:v1.16.3-1.0,v1.16-1,edge \
+	v1.16/debian:v1.16.3-debian-amd64-1.0,v1.16-debian-amd64-1,edge-debian-amd64
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 
 # Define images for running on ARM platforms
 ARM_IMAGES := \
-	v1.16/armhf/debian:v1.16.2-debian-armhf-1.1,v1.16-debian-armhf-1,edge-debian-armhf \
+	v1.16/armhf/debian:v1.16.3-debian-armhf-1.0,v1.16-debian-armhf-1,edge-debian-armhf \
 
 # Define images for running on ARM64 platforms
 ARM64_IMAGES := \
-	v1.16/arm64/debian:v1.16.2-debian-arm64-1.1,v1.16-debian-arm64-1,edge-debian-arm64 \
+	v1.16/arm64/debian:v1.16.3-debian-arm64-1.0,v1.16-debian-arm64-1,edge-debian-arm64 \
 
 WINDOWS_IMAGES := \
-	v1.16/windows-ltsc2019:v1.16.2-windows-ltsc2019-1.1,v1.16-windows-ltsc2019-1 \
-	v1.16/windows-ltsc2022:v1.16.2-windows-ltsc2022-1.1,v1.16-windows-ltsc2022-1
+	v1.16/windows-ltsc2019:v1.16.3-windows-ltsc2019-1.0,v1.16-windows-ltsc2019-1 \
+	v1.16/windows-ltsc2022:v1.16.3-windows-ltsc2022-1.0,v1.16-windows-ltsc2022-1
 
 ALL_IMAGES := $(X86_IMAGES) $(ARM_IMAGES) $(ARM64_IMAGES) $(WINDOWS_IMAGES)
 

--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@ These tags have image version postfix. This updates many places so we need feedb
 
 Current images use fluentd v1 series.
 
-- `v1.16.2-1.1`, `v1.16-1`, `edge`
+- `v1.16.3-1.0`, `v1.16-1`, `edge`
   [(v1.16/alpine/Dockerfile)][fluentd-1-alpine]
-- `v1.16.2-debian-1.1`, `v1.16-debian-1`, `edge-debian`
+- `v1.16.3-debian-1.0`, `v1.16-debian-1`, `edge-debian`
   (multiarch image for arm64(AArch64) and amd64(x86_64))
-- `v1.16.2-debian-amd64-1.1`, `v1.16-debian-amd64-1`, `edge-debian-amd64`
+- `v1.16.3-debian-amd64-1.0`, `v1.16-debian-amd64-1`, `edge-debian-amd64`
   [(v1.16/debian/Dockerfile)][fluentd-1-debian]
-- `v1.16.2-debian-arm64-1.1`, `v1.16-debian-arm64-1`, `edge-debian-arm64`
+- `v1.16.3-debian-arm64-1.0`, `v1.16-debian-arm64-1`, `edge-debian-arm64`
   [(v1.16/arm64/debian/Dockerfile)][fluentd-1-debian-arm64]
-- `v1.16.2-debian-armhf-1.1`, `v1.16-debian-armhf-1`, `edge-debian-armhf`
+- `v1.16.3-debian-armhf-1.0`, `v1.16-debian-armhf-1`, `edge-debian-armhf`
   [(v1.16/armhf/debian/Dockerfile)][fluentd-1-debian-armhf]
-- `v1.16.2-windows-ltsc2019-1.1`, `v1.16-windows-ltsc2019-1`
+- `v1.16.3-windows-ltsc2019-1.0`, `v1.16-windows-ltsc2019-1`
   [(v1.16/windows-ltsc2019/Dockerfile)][fluentd-1-ltsc2019-windows]
-- `v1.16.2-windows-ltsc2022-1.1`, `v1.16-windows-ltsc2022-1`
+- `v1.16.3-windows-ltsc2022-1.0`, `v1.16-windows-ltsc2022-1`
   [(v1.16/windows-ltsc2022/Dockerfile)][fluentd-1-ltsc2022-windows]
 
 ### Old v1.4 images

--- a/v1.16/alpine/Dockerfile
+++ b/v1.16/alpine/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM alpine:3.17
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.2"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.3"
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -24,7 +24,7 @@ RUN apk update \
  && gem install async-http -v 0.60.2 \
 # CVE-2023-36617
 && gem install uri -v 0.12.2 \
- && gem install fluentd -v 1.16.2 \
+ && gem install fluentd -v 1.16.3 \
  && gem install bigdecimal -v 1.4.4 \
  && apk del .build-deps \
  && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem /usr/lib/ruby/gems/3.*/gems/fluentd-*/test

--- a/v1.16/alpine/hooks/post_push
+++ b/v1.16/alpine/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.16.2-1.1,v1.16-1,edge}; do
+for tag in {v1.16.3-1.0,v1.16-1,edge}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 

--- a/v1.16/arm64/debian/Dockerfile
+++ b/v1.16/arm64/debian/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/q
 FROM arm64v8/ruby:3.1-slim-bullseye
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.2"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.3"
 ARG CROSS_BUILD_START="cross-build-start"
 ARG CROSS_BUILD_END="cross-build-end"
 RUN [ ${CROSS_BUILD_START} ]
@@ -36,7 +36,7 @@ RUN apt-get update \
  && gem install async-http -v 0.60.2 \
 # CVE-2023-36617
 && gem install uri -v 0.12.2 \
- && gem install fluentd -v 1.16.2 \
+ && gem install fluentd -v 1.16.3 \
  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch" \
  && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \

--- a/v1.16/arm64/debian/hooks/post_push
+++ b/v1.16/arm64/debian/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image for each additional tag
-for tag in {v1.16.2-debian-arm64-1.1,v1.16-debian-arm64-1,edge-debian-arm64}; do
+for tag in {v1.16.3-debian-arm64-1.0,v1.16-debian-arm64-1,edge-debian-arm64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 

--- a/v1.16/armhf/debian/Dockerfile
+++ b/v1.16/armhf/debian/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -sL -o qemu-3.0.0+resin-arm.tar.gz https://github.com/balena-io/qemu/re
 FROM arm32v7/ruby:3.1-slim-bullseye
 COPY --from=builder /go/qemu-arm-static /usr/bin/
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.2"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.3"
 ARG CROSS_BUILD_START="cross-build-start"
 ARG CROSS_BUILD_END="cross-build-end"
 RUN [ ${CROSS_BUILD_START} ]
@@ -36,7 +36,7 @@ RUN apt-get update \
  && gem install async-http -v 0.60.2 \
 # CVE-2023-36617
 && gem install uri -v 0.12.2 \
- && gem install fluentd -v 1.16.2 \
+ && gem install fluentd -v 1.16.3 \
  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch" \
  && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \

--- a/v1.16/armhf/debian/hooks/post_push
+++ b/v1.16/armhf/debian/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.16.2-debian-armhf-1.1,v1.16-debian-armhf-1,edge-debian-armhf}; do
+for tag in {v1.16.3-debian-armhf-1.0,v1.16-debian-armhf-1,edge-debian-armhf}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 

--- a/v1.16/debian/Dockerfile
+++ b/v1.16/debian/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM ruby:3.1-slim-bullseye
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.2"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.3"
 ENV TINI_VERSION=0.18.0
 
 # Do not split this into multiple RUN!
@@ -25,7 +25,7 @@ RUN apt-get update \
  && gem install async-http -v 0.60.2 \
 # CVE-2023-36617
 && gem install uri -v 0.12.2 \
- && gem install fluentd -v 1.16.2 \
+ && gem install fluentd -v 1.16.3 \
  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch" \
  && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-$dpkgArch.asc" \

--- a/v1.16/debian/hooks/post_push
+++ b/v1.16/debian/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image for each additional tag
-for tag in {v1.16.2-debian-amd64-1.1,v1.16-debian-amd64-1,edge-debian-amd64}; do
+for tag in {v1.16.3-debian-amd64-1.0,v1.16-debian-amd64-1,edge-debian-amd64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 

--- a/v1.16/windows-ltsc2019/Dockerfile
+++ b/v1.16/windows-ltsc2019/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.2"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.3"
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -11,7 +11,7 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 
 # NOTE: For avoiding stalling with docker build on windows, we must use latest version of msys2.
 RUN choco install -y ruby --version 3.1.3.1 --params "'/InstallDir:C:\ruby31'" \
-&& choco install -y msys2 --version 20230718.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby31\msys64'"
+&& choco install -y msys2 --version 20231026.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby31\msys64'"
 RUN refreshenv \
 && ridk install 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
@@ -20,7 +20,7 @@ RUN refreshenv \
 && gem install rexml -v 3.2.6 \
 # CVE-2023-36617
 && gem install uri -v 0.12.2 \
-&& gem install fluentd -v 1.16.2 \
+&& gem install fluentd -v 1.16.3 \
 && gem install win32-service -v 2.3.2 \
 && gem install win32-ipc -v 0.7.0 \
 && gem install win32-event -v 0.6.3 \

--- a/v1.16/windows-ltsc2019/hooks/post_push
+++ b/v1.16/windows-ltsc2019/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.16.2-windows-ltsc2019-1.1,v1.16-windows-ltsc2019-1}; do
+for tag in {v1.16.3-windows-ltsc2019-1.0,v1.16-windows-ltsc2019-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 

--- a/v1.16/windows-ltsc2022/Dockerfile
+++ b/v1.16/windows-ltsc2022/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2022
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
-LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.2"
+LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.3"
 
 # Do not split this into multiple RUN!
 # Docker creates a layer for every RUN-Statement
@@ -11,7 +11,7 @@ RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex (
 
 # NOTE: For avoiding stalling with docker build on windows, we must use latest version of msys2.
 RUN choco install -y ruby --version 3.1.3.1 --params "'/InstallDir:C:\ruby31'" \
-&& choco install -y msys2 --version 20230718.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby31\msys64'"
+&& choco install -y msys2 --version 20231026.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby31\msys64'"
 RUN refreshenv \
 && ridk install 3 \
 && echo gem: --no-document >> C:\ProgramData\gemrc \
@@ -20,7 +20,7 @@ RUN refreshenv \
 && gem install rexml -v 3.2.6 \
 # CVE-2023-36617
 && gem install uri -v 0.12.2 \
-&& gem install fluentd -v 1.16.2 \
+&& gem install fluentd -v 1.16.3 \
 && gem install win32-service -v 2.3.2 \
 && gem install win32-ipc -v 0.7.0 \
 && gem install win32-event -v 0.6.3 \

--- a/v1.16/windows-ltsc2022/hooks/post_push
+++ b/v1.16/windows-ltsc2022/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.16.2-windows-ltsc2022-1.1,v1.16-windows-ltsc2022-1}; do
+for tag in {v1.16.3-windows-ltsc2022-1.0,v1.16-windows-ltsc2022-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 


### PR DESCRIPTION
This is intended to apply update to fix CVE-2023-4911.

See

* https://security-tracker.debian.org/tracker/CVE-2023-4911
* https://tracker.debian.org/news/1468062/accepted-glibc-231-13deb11u7-source-into-oldstable-security/

Related:

  https://github.com/fluent/fluentd-kubernetes-daemonset/issues/1464