### PR TITLE
Fix FTBFS armhf/arm64 container

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -29,7 +29,7 @@ ENV QEMU_DOWNLOAD_SHA256 47ae430b0e7c25e1bde290ac447a720e2ea6c6e78cd84e44847edda
 RUN apk add curl --no-cache
 RUN curl -sL -o qemu-3.0.0+resin-arm.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-arm.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-arm.tar.gz -C . && mv qemu-3.0.0+resin-arm/qemu-arm-static .
 
-FROM arm32v7/ruby:3.2-slim-bookworm
+FROM --platform=linux/arm/v7 arm32v7/ruby:3.2-slim-bookworm
 COPY --from=builder /go/qemu-arm-static /usr/bin/
 <% elsif is_arm64 %>
 # To set multiarch build for Docker hub automated build.
@@ -39,7 +39,7 @@ ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf61
 RUN apk add curl --no-cache
 RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
-FROM arm64v8/ruby:3.2-slim-bookworm
+FROM --platform=linux/arm64 arm64v8/ruby:3.2-slim-bookworm
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/
 <% else %>
 FROM ruby:3.2-slim-bookworm

--- a/v1.16/arm64/debian/Dockerfile
+++ b/v1.16/arm64/debian/Dockerfile
@@ -8,7 +8,7 @@ ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf61
 RUN apk add curl --no-cache
 RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
-FROM arm64v8/ruby:3.2-slim-bookworm
+FROM --platform=linux/arm64 arm64v8/ruby:3.2-slim-bookworm
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.3"

--- a/v1.16/armhf/debian/Dockerfile
+++ b/v1.16/armhf/debian/Dockerfile
@@ -8,7 +8,7 @@ ENV QEMU_DOWNLOAD_SHA256 47ae430b0e7c25e1bde290ac447a720e2ea6c6e78cd84e44847edda
 RUN apk add curl --no-cache
 RUN curl -sL -o qemu-3.0.0+resin-arm.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-arm.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-arm.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-arm.tar.gz -C . && mv qemu-3.0.0+resin-arm/qemu-arm-static .
 
-FROM arm32v7/ruby:3.2-slim-bookworm
+FROM --platform=linux/arm/v7 arm32v7/ruby:3.2-slim-bookworm
 COPY --from=builder /go/qemu-arm-static /usr/bin/
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.3"


### PR DESCRIPTION
It fixes the following pulling error:

```
  [internal] load metadata for docker.io/arm64v8/ruby:3.2-slim-bookworm
  ERROR: no match for platform in manifest sha256:cea245cfb9be0f245a587a1fef559ef42e11742d9b9d81a36ccb8a816c2ca053: not found
```

  or

```
  no matching manifest for linux/amd64 in the manifest list entries
```

