### PR TITLE
Fix cleanup path for windows container

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -88,7 +88,7 @@ RUN refreshenv \
 && gem sources --clear-all
 
 # Remove gem cache and chocolatey
-RUN powershell -Command "Remove-Item -Force C:\ruby31\lib\ruby\gems\3.1.0\cache\*.gem; Remove-Item -Recurse -Force 'C:\ProgramData\chocolatey'"
+RUN powershell -Command "Remove-Item -Force C:\ruby32\lib\ruby\gems\3.2.0\cache\*.gem; Remove-Item -Recurse -Force 'C:\ProgramData\chocolatey'"
 
 COPY fluent.conf /fluent/conf/fluent.conf
 <% else %>

--- a/v1.17/windows-ltsc2019/Dockerfile
+++ b/v1.17/windows-ltsc2019/Dockerfile
@@ -25,7 +25,7 @@ RUN refreshenv \
 && gem sources --clear-all
 
 # Remove gem cache and chocolatey
-RUN powershell -Command "Remove-Item -Force C:\ruby31\lib\ruby\gems\3.1.0\cache\*.gem; Remove-Item -Recurse -Force 'C:\ProgramData\chocolatey'"
+RUN powershell -Command "Remove-Item -Force C:\ruby32\lib\ruby\gems\3.2.0\cache\*.gem; Remove-Item -Recurse -Force 'C:\ProgramData\chocolatey'"
 
 COPY fluent.conf /fluent/conf/fluent.conf
 

--- a/v1.17/windows-ltsc2022/Dockerfile
+++ b/v1.17/windows-ltsc2022/Dockerfile
@@ -25,7 +25,7 @@ RUN refreshenv \
 && gem sources --clear-all
 
 # Remove gem cache and chocolatey
-RUN powershell -Command "Remove-Item -Force C:\ruby31\lib\ruby\gems\3.1.0\cache\*.gem; Remove-Item -Recurse -Force 'C:\ProgramData\chocolatey'"
+RUN powershell -Command "Remove-Item -Force C:\ruby32\lib\ruby\gems\3.2.0\cache\*.gem; Remove-Item -Recurse -Force 'C:\ProgramData\chocolatey'"
 
 COPY fluent.conf /fluent/conf/fluent.conf
 


### PR DESCRIPTION
As newer Ruby 3.2 was installed into C:\ruby32 for v1.17 branch,
    the path of cleanup cache also fixed.
