### PR TITLE
windows: fix gem: --no-document in gemrc

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -68,7 +68,9 @@ RUN choco install -y ruby --version 3.2.4.1 --params "'/InstallDir:C:\ruby32'" \
 && choco install -y msys2 --version 20240507.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby32\msys64'"
 RUN refreshenv \
 && ridk install 3 \
-&& echo gem: --no-document >> C:\ProgramData\gemrc \
+&& type "c:\ProgramData\gemrc" \
+&& c:\ruby32\bin\ruby -e "require 'yaml'; File.open('c:/ProgramData/gemrc') do |file| yaml = YAML.safe_load(file); yaml['install'] = '--no-document'; yaml['update'] = '--no-document'; File.open('c:/ProgramData/gemrc', 'w+') do |output| output.puts(YAML.dump(yaml)); end; end" \
+&& type "c:\ProgramData\gemrc" \
 && gem install oj -v 3.16.5 \
 && gem install json -v 2.7.2 \
 && gem install rexml -v 3.3.5 \

--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -69,7 +69,7 @@ RUN choco install -y ruby --version 3.2.4.1 --params "'/InstallDir:C:\ruby32'" \
 RUN refreshenv \
 && ridk install 3 \
 && type "c:\ProgramData\gemrc" \
-&& c:\ruby32\bin\ruby -e "require 'yaml'; File.open('c:/ProgramData/gemrc') do |file| yaml = YAML.safe_load(file); yaml['install'] = '--no-document'; yaml['update'] = '--no-document'; File.open('c:/ProgramData/gemrc', 'w+') do |output| output.puts(YAML.dump(yaml)); end; end" \
+&& c:\ruby32\bin\ruby -r yaml -e "path = 'c:/ProgramData/gemrc'; yaml = YAML.safe_load(File.read(path)); yaml['install'] = '--no-document'; yaml['update'] = '--no-document'; File.write(path, YAML.dump(yaml))" \
 && type "c:\ProgramData\gemrc" \
 && gem install oj -v 3.16.5 \
 && gem install json -v 2.7.2 \

--- a/v1.17/windows-ltsc2019/Dockerfile
+++ b/v1.17/windows-ltsc2019/Dockerfile
@@ -14,7 +14,9 @@ RUN choco install -y ruby --version 3.2.4.1 --params "'/InstallDir:C:\ruby32'" \
 && choco install -y msys2 --version 20240507.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby32\msys64'"
 RUN refreshenv \
 && ridk install 3 \
-&& echo gem: --no-document >> C:\ProgramData\gemrc \
+&& type "c:\ProgramData\gemrc" \
+&& c:\ruby32\bin\ruby -r yaml -e "path = 'c:/ProgramData/gemrc'; yaml = YAML.safe_load(File.read(path)); yaml['install'] = '--no-document'; yaml['update'] = '--no-document'; File.write(path, YAML.dump(yaml))" \
+&& type "c:\ProgramData\gemrc" \
 && gem install oj -v 3.16.5 \
 && gem install json -v 2.7.2 \
 && gem install rexml -v 3.3.5 \

--- a/v1.17/windows-ltsc2022/Dockerfile
+++ b/v1.17/windows-ltsc2022/Dockerfile
@@ -14,7 +14,9 @@ RUN choco install -y ruby --version 3.2.4.1 --params "'/InstallDir:C:\ruby32'" \
 && choco install -y msys2 --version 20240507.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby32\msys64'"
 RUN refreshenv \
 && ridk install 3 \
-&& echo gem: --no-document >> C:\ProgramData\gemrc \
+&& type "c:\ProgramData\gemrc" \
+&& c:\ruby32\bin\ruby -r yaml -e "path = 'c:/ProgramData/gemrc'; yaml = YAML.safe_load(File.read(path)); yaml['install'] = '--no-document'; yaml['update'] = '--no-document'; File.write(path, YAML.dump(yaml))" \
+&& type "c:\ProgramData\gemrc" \
 && gem install oj -v 3.16.5 \
 && gem install json -v 2.7.2 \
 && gem install rexml -v 3.3.5 \


### PR DESCRIPTION
In the previous versions, append gem: --no-document for c:\ProgramData\gemrc, but it does not work as expected because the default gemrc content is different as we thought.

So, we should override explicitly by gem: --no-document here.

Checked with installing json gem about this behavior.

```
  C:\>type c:\ProgramData\gemrc
  # This is the system wide config file for Rubygems.
  # It is generated by RubyInstaller as a security measure.
  # Feel free to add any rubygems config options as described on:
  #    https://docs.ruby-lang.org/en/3.1/Gem/ConfigFile.html
  # But do not delete this file as otherwise it could be hijacked by
  # another user in a multi-user environment.
  ---
  {}
  gem: --no-document

  C:\>echo gem: --no-document > c:\ProgramData\gemrc

  C:\>type c:\ProgramData\gemrc
  gem: --no-document

  C:\>gem install json
  Fetching json-2.7.2.gem
  Temporarily enhancing PATH for MSYS/MINGW...
  Building native extensions. This could take a while...
  Successfully installed json-2.7.2
  1 gem installed
```
