### PR TITLE
Do not remove so exessively

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -117,7 +117,7 @@ RUN apt-get update \
  && echo GEM_DIR=$GEM_DIR \
  && rm -rf $GEM_DIR/cache/*.gem \
  # Don't purge $GEM_DIR/gems/GEM/lib/GEM/ext because it might contain runtime .so (e.g json)
- && find $GEM_DIR -maxdepth 3 -type d -name test -or -name ext -or -name spec -or -name benchmark | xargs -r rm -rf \
+ && find $GEM_DIR -maxdepth 3 -type d -name test -or -name ext -or -name spec -or -name benchmark | xargs -r rm -rfv \
  && find $GEM_DIR -name "*.so" | xargs -r strip \
 <% if is_alpine %>
  && gem install bigdecimal -v 1.4.4 \

--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -116,7 +116,8 @@ RUN apt-get update \
  && export GEM_DIR=$(ruby -e 'puts Gem.dir') \
  && echo GEM_DIR=$GEM_DIR \
  && rm -rf $GEM_DIR/cache/*.gem \
- && find $GEM_DIR -type d -name test -or -name ext -or -name spec -or -name benchmark | xargs -r rm -rf \
+ # Don't purge $GEM_DIR/gems/GEM/lib/GEM/ext because it might contain runtime .so (e.g json)
+ && find $GEM_DIR -maxdepth 3 -type d -name test -or -name ext -or -name spec -or -name benchmark | xargs -r rm -rf \
  && find $GEM_DIR -name "*.so" | xargs -r strip \
 <% if is_alpine %>
  && gem install bigdecimal -v 1.4.4 \


### PR DESCRIPTION
In the previous version, it will remove required runtime so with find && rm.

This is apparently bug with it.

See https://github.com/fluent/fluent-plugin-s3/issues/449