### PR TITLE
ci: add workflow to deploy container images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,256 @@
+name: Publish Docker Image
+
+on:
+  push:
+    tags:
+      - v1.*
+
+concurrency:
+  group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+env:
+  REPOSITORY: ${{ secrets.DOCKER_HUB_ORGS }}/fluentd-docker-image
+jobs:
+  define-matrix:
+    runs-on: ubuntu-latest
+    env:
+      ALL_COMPONENTS: >
+        [
+        "alpine",
+        "arm64",
+        "armhf",
+        "amd64",
+        ]
+    outputs:
+      components: >
+        ${{ steps.arrange-components.outputs.for_all == 'true' && env.ALL_COMPONENTS
+        || format('["{0}"]', steps.arrange-components.outputs.component) }}
+    steps:
+      - id: arrange-components
+        run: |
+          echo "for_all=true" >> "$GITHUB_OUTPUT"
+          for component in ${{ join(fromJSON(env.ALL_COMPONENTS), ' ') }}; do
+            if [[ ${{ github.ref_name }} == *"$component"* ]]; then
+              echo "for_all=false" >> "$GITHUB_OUTPUT"
+              echo "component=$component" >> "$GITHUB_OUTPUT"
+              break
+            fi
+          done
+  build:
+    needs: define-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        component: ${{ fromJSON(needs.define-matrix.outputs.components) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7 # armhf
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Setup tags
+        run: |
+          set -x
+          component=${{ matrix.component }}
+          for target in $(make echo-all-images); do
+            case $target in
+               *$component*)
+                 ;;
+               *)
+                 continue
+                 ;;
+            esac
+            branch=$(echo $target | cut -d'/' -f1)
+            tags=$(echo $target | cut -d':' -f2-)
+            tag1=$(echo $tags | cut -d',' -f1)
+            tag2=$(echo $tags | cut -d',' -f2)
+            tag3=$(echo $tags | cut -d',' -f3)
+            case $component in
+            *alpine*)
+              echo "CONTEXT=${branch}/${component}" >> ${GITHUB_ENV}
+              echo "ALPINETAGS=${{ env.REPOSITORY }}:${tag1},${{ env.REPOSITORY }}:${tag2},${{ env.REPOSITORY }}:${tag3}" >> ${GITHUB_ENV}
+              ;;
+            *arm64*)
+              echo "CONTEXT=${branch}/${component}/debian" >> ${GITHUB_ENV}
+              echo "ARM64TAGS=${{ env.REPOSITORY }}:${tag1},${{ env.REPOSITORY }}:${tag2},${{ env.REPOSITORY }}:${tag3}" >> ${GITHUB_ENV}
+              ;;
+            *armhf*)
+              echo "CONTEXT=${branch}/${component}/debian" >> ${GITHUB_ENV}
+              echo "ARMHFTAGS=${{ env.REPOSITORY }}:${tag1},${{ env.REPOSITORY }}:${tag2},${{ env.REPOSITORY }}:${tag3}" >> ${GITHUB_ENV}
+              ;;
+            *amd64*)
+              echo "CONTEXT=${branch}/debian" >> ${GITHUB_ENV}
+              echo "AMD64TAGS=${{ env.REPOSITORY }}:${tag1},${{ env.REPOSITORY }}:${tag2},${{ env.REPOSITORY }}:${tag3}" >> ${GITHUB_ENV}
+              ;;
+            esac
+          done
+      - name: Build and push for alpine
+        if: ${{ env.ALPINETAGS }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.CONTEXT }}
+          provenance: false
+          push: true
+          platforms: linux/amd64
+          tags: ${{ env.ALPINETAGS }}
+          # dare to use old mediatype (application/vnd.docker.distribution.manifest.v2+json)
+          outputs: oci-mediatypes=false
+      - name: Build and push for amd64
+        if: ${{ env.AMD64TAGS }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.CONTEXT }}
+          provenance: false
+          push: true
+          platforms: linux/amd64
+          tags: ${{ env.AMD64TAGS }}
+          # dare to use old mediatype (application/vnd.docker.distribution.manifest.v2+json)
+          outputs: oci-mediatypes=false
+      - name: Build and push for arm64
+        if: ${{ env.ARM64TAGS }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.CONTEXT }}
+          provenance: false
+          push: true
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ env.ARM64TAGS }}
+          # dare to use old mediatype (application/vnd.docker.distribution.manifest.v2+json)
+          outputs: oci-mediatypes=false
+      - name: Build and push for armhf
+        if: ${{ env.ARMHFTAGS }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.CONTEXT }}
+          provenance: false
+          push: true
+          platforms: linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ env.ARMHFTAGS }}
+          # dare to use old mediatype (application/vnd.docker.distribution.manifest.v2+json)
+          outputs: oci-mediatypes=false
+  manifest:
+    needs: [define-matrix, build]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        component: ${{ fromJSON(needs.define-matrix.outputs.components) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Create manifest
+        if: ${{ matrix.component }} != "alpine"
+        run: |
+          component=${{ matrix.component }}
+          for target in $(make echo-all-images); do
+            tags=$(echo $target | cut -d':' -f2-)
+            tag1=$(echo $tags | cut -d',' -f1)
+            tag2=$(echo $tags | cut -d',' -f2)
+            tag3=$(echo $tags | cut -d',' -f3)
+            case $target in
+              *amd64*)
+                MULTIARCH_AMD64_TAG=${tag1/amd64-/}
+                MULTIARCH_AMD64_SHORT_TAG=${tag2/amd64-/}
+                AMD64TAG=${tag1}
+                SHORT_AMD64TAG=${tag2}
+                ;;
+              *arm64*)
+                MULTIARCH_ARM64_TAG=${tag1/arm64-/}
+                MULTIARCH_ARM64_SHORT_TAG=${tag2/arm64-/}
+                ARM64TAG=${tag1}
+                SHORT_ARM64TAG=${tag2}
+                ;;
+              *armhf*)
+                MULTIARCH_ARMHF_TAG=${tag1/armhf-/}
+                MULTIARCH_ARMHF_SHORT_TAG=${tag2/armhf-/}
+                ARMHFTAG=${tag1}
+                SHORT_ARMHFTAG=${tag2}
+                ;;
+              *alpine*)
+                ;;
+            esac
+          done
+          # v1.xx.y-debian-n.m
+          if [ ${MULTIARCH_AMD64_TAG} != ${MULTIARCH_ARM64_TAG} -o ${MULTIARCH_AMD64_TAG} != ${MULTIARCH_ARMHF_TAG} -o ${MULTIARCH_ARM64_TAG} != ${MULTIARCH_ARMHF_TAG} ]; then
+            echo "Multiarch tag (v1.x.y-debian-(ARCH)-n.m) must be same for amd64, arm64 and armhf: ${MULTIARCH_AMD64_TAG}, ${MULTIARCH_ARM64_TAG}, ${MULTIARCH_ARMHF_TAG}"
+          else
+            docker buildx imagetools create -t ${{ env.REPOSITORY }}:${MULTIARCH_AMD64_TAG} \
+              ${{ env.REPOSITORY }}:${AMD64TAG} \
+              ${{ env.REPOSITORY }}:${ARM64TAG} \
+              ${{ env.REPOSITORY }}:${ARMHFTAG}
+          fi
+          # v1.xx-debian-n.m
+          if [ ${MULTIARCH_AMD64_SHORT_TAG} != ${MULTIARCH_ARM64_SHORT_TAG} -o ${MULTIARCH_AMD64_SHORT_TAG} != ${MULTIARCH_ARMHF_SHORT_TAG} -o ${MULTIARCH_ARM64_SHORT_TAG} != ${MULTIARCH_ARMHF_SHORT_TAG} ]; then
+            echo "Multiarch tag (v1.xx-debian-n.m must be same for amd64, arm64 and armhf: ${MULTIARCH_AMD64_SHORT_TAG}, ${MULTIARCH_ARM64_SHORT_TAG}, ${MULTIARCH_ARMHF_SHORT_TAG}"
+          else
+            docker buildx imagetools create -t ${{ env.REPOSITORY }}:${MULTIARCH_AMD64_SHORT_TAG} \
+              ${{ env.REPOSITORY }}:${SHORT_AMD64TAG} \
+              ${{ env.REPOSITORY }}:${SHORT_ARM64TAG} \
+              ${{ env.REPOSITORY }}:${SHORT_ARMHFTAG}
+          fi
+          # edge-debian
+          docker buildx imagetools create -t ${{ env.REPOSITORY }}:edge-debian \
+              ${{ env.REPOSITORY }}:edge-debian-amd64 \
+              ${{ env.REPOSITORY }}:edge-debian-arm64 \
+              ${{ env.REPOSITORY }}:edge-debian-armhf
+          echo "MULTIARCH_AMD64_TAG=${MULTIARCH_AMD64_TAG}" >> ${GITHUB_ENV}
+          echo "MULTIARCH_AMD64_SHORT_TAG=${MULTIARCH_AMD64_SHORT_TAG}" >> ${GITHUB_ENV}
+          echo "AMD64TAG=${AMD64TAG}" >> ${GITHUB_ENV}
+          echo "SHORT_AMD64TAG=${SHORT_ARM64TAG}" >> ${GITHUB_ENV}
+          echo "MULTIARCH_ARM64_TAG=${MULTIARCH_ARM64_TAG}" >> ${GITHUB_ENV}
+          echo "MULTIARCH_ARM64_SHORT_TAG=${MULTIARCH_ARM64_SHORT_TAG}" >> ${GITHUB_ENV}
+          echo "ARM64TAG=${ARM64TAG}" >> ${GITHUB_ENV}
+          echo "SHORT_ARM64TAG=${SHORT_ARM64TAG}" >> ${GITHUB_ENV}
+          echo "MULTIARCH_ARMHF_TAG=${MULTIARCH_ARMHF_TAG}" >> ${GITHUB_ENV}
+          echo "MULTIARCH_ARMHF_SHORT_TAG=${MULTIARCH_ARMHF_SHORT_TAG}" >> ${GITHUB_ENV}
+          echo "ARMHFTAG=${ARMHFTAG}" >> ${GITHUB_ENV}
+          echo "SHORT_ARMHFTAG=${SHORT_ARMHFTAG}" >> ${GITHUB_ENV}
+      - name: Inspect manifest ${{ env.AMD64TAG }}
+        run: docker manifest inspect ${{ env.REPOSITORY }}:${{ env.AMD64TAG }}
+      - name: Inspect manifest ${{ env.ARM64TAG }}
+        run: docker manifest inspect ${{ env.REPOSITORY }}:${{ env.ARM64TAG }}
+      - name: Inspect manifest ${{ env.ARMHFTAG }}
+        run: docker manifest inspect ${{ env.REPOSITORY }}:${{ env.ARMHFTAG }}
+      - name: Inspect manifest ${{ env.MULTIARCH_AMD64_TAG }}
+        run: docker manifest inspect ${{ env.REPOSITORY }}:${{ env.MULTIARCH_AMD64_TAG }}
+      - name: Inspect manifest ${{ env.MULTIARCH_ARM64_TAG }}
+        run: docker manifest inspect ${{ env.REPOSITORY }}:${{ env.MULTIARCH_ARM64_TAG }}
+      - name: Inspect manifest ${{ env.MULTIARCH_ARMHF_TAG }}
+        run: docker manifest inspect ${{ env.REPOSITORY }}:${{ env.MULTIARCH_ARMHF_TAG }}
+      - name: Inspect manifest ${{ env.MULTIARCH_AMD64_SHORT_TAG }}
+        run: docker manifest inspect ${{ env.REPOSITORY }}:${{ env.MULTIARCH_AMD64_SHORT_TAG }}
+      - name: Inspect manifest ${{ env.MULTIARCH_ARM64_SHORT_TAG }}
+        run: docker manifest inspect ${{ env.REPOSITORY }}:${{ env.MULTIARCH_ARM64_SHORT_TAG }}
+      - name: Inspect manifest ${{ env.MULTIARCH_ARMHF_SHORT_TAG }}
+        run: docker manifest inspect ${{ env.REPOSITORY }}:${{ env.MULTIARCH_ARMHF_SHORT_TAG }}
+      - name: Inspect ${{ env.AMD64TAG }} with buildx
+        run: docker buildx imagetools inspect ${{ env.REPOSITORY }}:${{ env.AMD64TAG }}
+      - name: Inspect ${{ env.ARM64TAG }} with buildx
+        run: docker buildx imagetools inspect ${{ env.REPOSITORY }}:${{ env.ARM64TAG }}
+      - name: Inspect ${{ env.ARMHFTAG }} with buildx
+        run: docker buildx imagetools inspect ${{ env.REPOSITORY }}:${{ env.ARMHFTAG }}
+      - name: Inspect ${{ env.MULTIARCH_AMD64_TAG }} with buildx
+        run: docker buildx imagetools inspect ${{ env.REPOSITORY }}:${{ env.MULTIARCH_AMD64_TAG }}
+      - name: Inspect ${{ env.MULTIARCH_ARM64_TAG }} with buildx
+        run: docker buildx imagetools inspect ${{ env.REPOSITORY }}:${{ env.MULTIARCH_ARM64_TAG }}
+      - name: Inspect ${{ env.MULTIARCH_ARMHF_TAG }} with buildx
+        run: docker buildx imagetools inspect ${{ env.REPOSITORY }}:${{ env.MULTIARCH_ARMHF_TAG }}
+      - name: Inspect ${{ env.MULTIARCH_AMD64_SHORT_TAG }} with buildx
+        run: docker buildx imagetools inspect ${{ env.REPOSITORY }}:${{ env.MULTIARCH_AMD64_SHORT_TAG }}
+      - name: Inspect ${{ env.MULTIARCH_ARM64_SHORT_TAG }} with buildx
+        run: docker buildx imagetools inspect ${{ env.REPOSITORY }}:${{ env.MULTIARCH_ARM64_SHORT_TAG }}
+      - name: Inspect ${{ env.MULTIARCH_ARMHF_SHORT_TAG }} with buildx
+        run: docker buildx imagetools inspect ${{ env.REPOSITORY }}:${{ env.MULTIARCH_ARMHF_SHORT_TAG }}

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ TAGS ?= $(word 2,$(subst :, ,$(word 1,$(ALL_IMAGES))))
 
 no-cache ?= no
 
-
+echo-all-images:
+	@echo $(X86_IMAGES) $(ARM_IMAGES) $(ARM64_IMAGES)
 
 comma := ,
 empty :=
@@ -139,7 +140,7 @@ sbom-all:
 # Usage:
 #	make src [DOCKERFILE=] [VERSION=] [TAGS=t1,t2,...]
 
-src: dockerfile fluent.conf entrypoint.sh post-push-hook post-checkout-hook
+src: dockerfile fluent.conf entrypoint.sh post-checkout-hook
 
 
 


### PR DESCRIPTION
Before:

  Recently, the member of Docker Free Team organization can't trigger Automated
  builds from Web interface.

  It means that we can't ship newer image easily anymore.

After:

 Change deployment procedure to GitHub Actions.
 With this change, additionally ship triple multi-architecture
 tags for amd64, arm64 and armhf.

 NOTE:
 * v1.17.1-x.y tag ships alpine,amd64,arm64 and armhf images
 * v1.17.1-debian-amd64-1.2 tag ships only amd64 image and re-label multi-architecture tags.