### PR TITLE
Backport(v1.16) ci: enable arm64 build test

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,7 +16,9 @@ jobs:
         include:
           - dockerfile: v1.16/alpine
           - dockerfile: v1.16/debian
-    runs-on: ubuntu-latest
+          - dockerfile: v1.16/arm64/debian
+    runs-on: >-
+      ${{ (contains(matrix.dockerfile, 'arm64')) && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@master
       - name: Build


### PR DESCRIPTION
As already arm runner is available, so let's try it.