### PR TITLE
Bump version to v1.16.7-1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,17 +17,17 @@
 
 IMAGE_NAME := fluent/fluentd
 X86_IMAGES := \
-	v1.16/alpine:v1.16.7-1.0,v1.16-2,edge \
-	v1.16/debian:v1.16.7-debian-amd64-1.0,v1.16-debian-amd64-2,edge-debian-amd64
+	v1.16/alpine:v1.16.7-1.1,v1.16-2,edge \
+	v1.16/debian:v1.16.7-debian-amd64-1.1,v1.16-debian-amd64-2,edge-debian-amd64
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 
 # Define images for running on ARM platforms
 ARM_IMAGES := \
-	v1.16/armhf/debian:v1.16.7-debian-armhf-1.0,v1.16-debian-armhf-2,edge-debian-armhf \
+	v1.16/armhf/debian:v1.16.7-debian-armhf-1.1,v1.16-debian-armhf-2,edge-debian-armhf \
 
 # Define images for running on ARM64 platforms
 ARM64_IMAGES := \
-	v1.16/arm64/debian:v1.16.7-debian-arm64-1.0,v1.16-debian-arm64-2,edge-debian-arm64 \
+	v1.16/arm64/debian:v1.16.7-debian-arm64-1.1,v1.16-debian-arm64-2,edge-debian-arm64 \
 
 WINDOWS_IMAGES := \
 	v1.16/windows-ltsc2019:v1.16.7-windows-ltsc2019-1.0,v1.16-windows-ltsc2019-1 \

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ These tags have image version postfix. This updates many places so we need feedb
 
 Current images use fluentd v1 series.
 
-- `v1.16.7-1.0`, `v1.16-2`, `edge`
+- `v1.16.7-1.1`, `v1.16-2`, `edge`
   [(v1.16/alpine/Dockerfile)][fluentd-1-alpine]
-- `v1.16.7-debian-1.0`, `v1.16-debian-2`, `edge-debian`
+- `v1.16.7-debian-1.1`, `v1.16-debian-2`, `edge-debian`
   (multiarch image for arm64(AArch64) and amd64(x86_64))
-- `v1.16.7-debian-amd64-1.0`, `v1.16-debian-amd64-2`, `edge-debian-amd64`
+- `v1.16.7-debian-amd64-1.1`, `v1.16-debian-amd64-2`, `edge-debian-amd64`
   [(v1.16/debian/Dockerfile)][fluentd-1-debian]
-- `v1.16.7-debian-arm64-1.0`, `v1.16-debian-arm64-2`, `edge-debian-arm64`
+- `v1.16.7-debian-arm64-1.1`, `v1.16-debian-arm64-2`, `edge-debian-arm64`
   [(v1.16/arm64/debian/Dockerfile)][fluentd-1-debian-arm64]
-- `v1.16.7-debian-armhf-1.0`, `v1.16-debian-armhf-2`, `edge-debian-armhf`
+- `v1.16.7-debian-armhf-1.1`, `v1.16-debian-armhf-2`, `edge-debian-armhf`
   [(v1.16/armhf/debian/Dockerfile)][fluentd-1-debian-armhf]
 - `v1.16.7-windows-ltsc2019-1.0`, `v1.16-windows-ltsc2019-1`
   [(v1.16/windows-ltsc2019/Dockerfile)][fluentd-1-ltsc2019-windows]


### PR DESCRIPTION
Rebuild arm64 image and re-publish via GitHub Action again.

The content itself is same as v1.16.7-1.0.
