### PR TITLE
Backport(v1.16): Use arm host to build arm64 image (#416)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,7 +39,8 @@ jobs:
           done
   build:
     needs: define-matrix
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{ (contains(matrix.component, 'arm64')) && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -34,13 +34,7 @@ COPY --from=builder /go/qemu-arm-static /usr/bin/
 <% elsif is_arm64 %>
 # To set multiarch build for Docker hub automated build.
 FROM golang:alpine AS builder
-WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
-RUN apk add curl --no-cache
-RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
-
 FROM --platform=linux/arm64 arm64v8/ruby:3.2-slim-bookworm
-COPY --from=builder /go/qemu-aarch64-static /usr/bin/
 <% else %>
 FROM ruby:3.2-slim-bookworm
 <% end %>
@@ -49,10 +43,6 @@ FROM ruby:3.2-slim-bookworm
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="<%= fluentd_ver %>"
 <% if is_armhf %>
-ARG CROSS_BUILD_START="cross-build-start"
-ARG CROSS_BUILD_END="cross-build-end"
-RUN [ ${CROSS_BUILD_START} ]
-<% elsif is_arm64 %>
 ARG CROSS_BUILD_START="cross-build-start"
 ARG CROSS_BUILD_END="cross-build-end"
 RUN [ ${CROSS_BUILD_START} ]
@@ -192,7 +182,7 @@ USER fluent
 ENTRYPOINT ["tini",  "--", "/bin/entrypoint.sh"]
 CMD ["fluentd"]
 
-<% if is_armhf || is_arm64 %>
+<% if is_armhf %>
 RUN [ ${CROSS_BUILD_END} ]
 <% end %>
 <% end %>

--- a/v1.16/arm64/debian/Dockerfile
+++ b/v1.16/arm64/debian/Dockerfile
@@ -3,18 +3,9 @@
 
 # To set multiarch build for Docker hub automated build.
 FROM golang:alpine AS builder
-WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
-RUN apk add curl --no-cache
-RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
-
 FROM --platform=linux/arm64 arm64v8/ruby:3.2-slim-bookworm
-COPY --from=builder /go/qemu-aarch64-static /usr/bin/
 LABEL maintainer "Fluentd developers <fluentd@googlegroups.com>"
 LABEL Description="Fluentd docker image" Vendor="Fluent Organization" Version="1.16.7"
-ARG CROSS_BUILD_START="cross-build-start"
-ARG CROSS_BUILD_END="cross-build-end"
-RUN [ ${CROSS_BUILD_START} ]
 ENV TINI_VERSION=0.18.0
 
 # Do not split this into multiple RUN!
@@ -78,4 +69,3 @@ USER fluent
 ENTRYPOINT ["tini",  "--", "/bin/entrypoint.sh"]
 CMD ["fluentd"]
 
-RUN [ ${CROSS_BUILD_END} ]


### PR DESCRIPTION
As QEMU on amd64 for building arm64 image cause SEGV issue, let's try to use arm64 runner directly.