### PR TITLE
Remove `apt-get upgrade` instances

### DIFF
--- a/Dockerfile.template.erb
+++ b/Dockerfile.template.erb
@@ -101,7 +101,6 @@ RUN apt-get update \
       make gcc g++ libc-dev \
       wget bzip2 gnupg dirmngr \
     " \
- && apt-get -V -y upgrade \
  && apt-get install -y --no-install-recommends $buildDeps \
 <% end %>
  && echo 'gem: --no-document' >> /etc/gemrc \

--- a/v1.16/arm64/debian/Dockerfile
+++ b/v1.16/arm64/debian/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update \
       make gcc g++ libc-dev \
       wget bzip2 gnupg dirmngr \
     " \
- && apt-get -V -y upgrade \
  && apt-get install -y --no-install-recommends $buildDeps \
  && echo 'gem: --no-document' >> /etc/gemrc \
  && gem install oj -v 3.16.1 \

--- a/v1.16/armhf/debian/Dockerfile
+++ b/v1.16/armhf/debian/Dockerfile
@@ -27,7 +27,6 @@ RUN apt-get update \
       make gcc g++ libc-dev \
       wget bzip2 gnupg dirmngr \
     " \
- && apt-get -V -y upgrade \
  && apt-get install -y --no-install-recommends $buildDeps \
  && echo 'gem: --no-document' >> /etc/gemrc \
  && gem install oj -v 3.16.1 \

--- a/v1.16/debian/Dockerfile
+++ b/v1.16/debian/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get update \
       make gcc g++ libc-dev \
       wget bzip2 gnupg dirmngr \
     " \
- && apt-get -V -y upgrade \
  && apt-get install -y --no-install-recommends $buildDeps \
  && echo 'gem: --no-document' >> /etc/gemrc \
  && gem install oj -v 3.16.1 \


### PR DESCRIPTION
This upgrades packages from the base layer in a lower layer, which bloats the layers.  The Docker Official Images instead update the base image, which in turn causes a rebuild that includes the updates packages.

- https://github.com/docker-library/official-images/pull/19076#issuecomment-2901911040
- https://github.com/fluent/fluentd-docker-image/pull/437#pullrequestreview-2861949008