### PR TITLE
Fix v1.xx.y-n.m tag generation

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -188,7 +188,7 @@ jobs:
               ${{ env.REPOSITORY }}:${ARM64TAG} \
               ${{ env.REPOSITORY }}:${ARMHFTAG}
             # v1.xx.y-n.m
-            VERSION_WITH_SUFFIX=${MULTIARCH_SHORT_ALIAS/debian-/}
+            VERSION_WITH_SUFFIX=${MULTIARCH_AMD64_TAG/debian-/}
             docker buildx imagetools create -t ${{ env.REPOSITORY }}:${VERSION_WITH_SUFFIX} \
               ${{ env.REPOSITORY }}:${AMD64TAG} \
               ${{ env.REPOSITORY }}:${ARM64TAG} \


### PR DESCRIPTION
In the previous version #439,  instead of v1.19.0-1.0,
tagged as v1.19.0-debian.

Before:

v1.19.0-debian-amd64-1.0 (tag1)
  => v1.19.0-debian-1.0 (MULTIARCH_AMD64_TAG)
  => v1.19.0-debian (MULTIARCH_SHORT_ALIAS this is wrong!)

After:

v1.19.0-debian-amd64-1.0 (tag1)
  => v1.19.0-debian-1.0 (MULTIARCH_AMD64_TAG)
  => v1.19.0-1.0