### PR TITLE
Add v1.19.0-2.1 images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,16 @@
 
 IMAGE_NAME := fluent/fluentd
 X86_IMAGES := \
-	v1.19/debian:v1.19.0-debian-amd64-2.0,v1.19-debian-amd64-2,v1.19.0-debian-amd64,edge-debian-amd64
+	v1.19/debian:v1.19.0-debian-amd64-2.1,v1.19-debian-amd64-2,v1.19.0-debian-amd64,edge-debian-amd64
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 
 # Define images for running on ARM platforms
 ARM_IMAGES := \
-	v1.19/armhf/debian:v1.19.0-debian-armhf-2.0,v1.19-debian-armhf-2,v1.19.0-debian-armhf,edge-debian-armhf
+	v1.19/armhf/debian:v1.19.0-debian-armhf-2.1,v1.19-debian-armhf-2,v1.19.0-debian-armhf,edge-debian-armhf
 
 # Define images for running on ARM64 platforms
 ARM64_IMAGES := \
-	v1.19/arm64/debian:v1.19.0-debian-arm64-2.0,v1.19-debian-arm64-2,v1.19.0-debian-arm64,edge-debian-arm64
+	v1.19/arm64/debian:v1.19.0-debian-arm64-2.1,v1.19-debian-arm64-2,v1.19.0-debian-arm64,edge-debian-arm64
 
 WINDOWS_IMAGES := \
 	v1.19/windows-ltsc2019:v1.19.0-windows-ltsc2019-1.0,v1.19-windows-ltsc2019-1 \

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ These tags have image version postfix. This updates many places so we need feedb
 
 Current images use fluentd v1 series.
 
-- `v1.19.0-2.0`, `v1.19-2`, `edge`, `latest`
+- `v1.19.0-2.1`, `v1.19-2`, `edge`, `latest`
   [(v1.19/debian/Dockerfile)][fluentd-1-debian] (Since v1.19.0, alpine image will not be shipped anymore.)
-- `v1.19.0-debian-2.0`, `v1.19-debian-2`, `edge-debian`
+- `v1.19.0-debian-2.1`, `v1.19-debian-2`, `edge-debian`
   (multiarch image for arm64(AArch64), armhf and amd64(x86_64))
-- `v1.19.0-debian-amd64-2.0`, `v1.19-debian-amd64-2`, `edge-debian-amd64`
+- `v1.19.0-debian-amd64-2.1`, `v1.19-debian-amd64-2`, `edge-debian-amd64`
   [(v1.19/debian/Dockerfile)][fluentd-1-debian]
-- `v1.19.0-debian-arm64-2.0`, `v1.19-debian-arm64-2`, `edge-debian-arm64`
+- `v1.19.0-debian-arm64-2.1`, `v1.19-debian-arm64-2`, `edge-debian-arm64`
   [(v1.19/arm64/debian/Dockerfile)][fluentd-1-debian-arm64]
-- `v1.19.0-debian-armhf-2.0`, `v1.19-debian-armhf-2`, `edge-debian-armhf`
+- `v1.19.0-debian-armhf-2.1`, `v1.19-debian-armhf-2`, `edge-debian-armhf`
   [(v1.19/armhf/debian/Dockerfile)][fluentd-1-debian-armhf]
 - `v1.19.0-windows-ltsc2019-1.0`, `v1.19-windows-ltsc2019-1`
   [(v1.19/windows-ltsc2019/Dockerfile)][fluentd-1-ltsc2019-windows]


### PR DESCRIPTION
As debian/trixie 13.1 was released, let's use it

https://hub.docker.com/layers/library/ruby/3.4-slim/images/sha256-80f389b6222196d76915f754158e0d92dc0c3d96f755bff7af1e360bb2f1a768