### PR TITLE
github: tweak dependabot behavior

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,21 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
+    groups:
+      # PR: "Security update [package] from [old] to [new]"
+      # This PR should be merged in hurry
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'
+
+      # PR: "Bump [package] from [old] to [new]"
+      # No need to be merged this PR in hurry. It is enough to merge
+      # once in a month.
+      monthly-updates:
+        applies-to: version-updates
+        patterns:
+          - '*'
+    # Allow to create PR both of security and normal updates.
+    open-pull-requests-limit: 1


### PR DESCRIPTION
Before:
* Dependabot Security Alerts were disabled.
* create PRs in weekly interval

After:
* Dependabot Security Alerts were disabled.
* Check security updates in daily, create a PR in timely manner
* Check normal updates in daily, create a PR, if you let alone, keep it rebased until merged into master.