### PR TITLE
Ensure to fetch latest FROM: for each release

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -103,6 +103,7 @@ jobs:
         with:
           context: ${{ env.CONTEXT }}
           provenance: false
+          pull: true
           push: true
           platforms: linux/amd64
           tags: ${{ env.AMD64TAGS }}
@@ -114,6 +115,7 @@ jobs:
         with:
           context: ${{ env.CONTEXT }}
           provenance: false
+          pull: true
           push: true
           platforms: linux/arm64
           cache-from: type=gha
@@ -127,6 +129,7 @@ jobs:
         with:
           context: ${{ env.CONTEXT }}
           provenance: false
+          pull: true
           push: true
           platforms: linux/arm/v7
           cache-from: type=gha


### PR DESCRIPTION
By default, pull: is set to false, so there is a case that updates from upstream is not synced yet.

See https://github.com/docker/build-push-action#customizing
 pull description.