### PR TITLE
ci: add link to security-tracker.debian.org

### DIFF
--- a/.github/actions/grype-scan/action.yml
+++ b/.github/actions/grype-scan/action.yml
@@ -50,7 +50,7 @@ runs:
           (["---","---","---","---"] | join(" | ") | "| " + . + " |"),
           (
             .matches
-            | map(select(.vulnerability.severity != "Negligible" and .vulnerability.severity != "negligible"))
+            | map(select(.artifact.type == "deb" and .vulnerability.severity != "Negligible" and .vulnerability.severity != "negligible"))
             | sort_by([
                 -(.vulnerability.severity | ascii_upcase | {"CRITICAL": 4,"HIGH": 3,"MEDIUM": 2,"LOW": 1}[.] // 0),
                 .vulnerability.id,

--- a/.github/actions/grype-scan/action.yml
+++ b/.github/actions/grype-scan/action.yml
@@ -41,6 +41,25 @@ runs:
             | "| \(.artifact.name) | \(.artifact.version) | \(.vulnerability.fix.versions[0] // (if .vulnerability.fix.state == "not-fixed" then "" else "(" + .vulnerability.fix.state + ")" end)) | \(.artifact.type) | \(.vulnerability.id) | \(.vulnerability.severity) |"
           )
         ' output.json >> $GITHUB_STEP_SUMMARY
+    - name: Add link to security-tracker.debian.org
+      shell: bash
+      run: |
+        echo "# Link to security-tracker.debian.org about ${{ inputs.image_name }} image (filter)" >> $GITHUB_STEP_SUMMARY
+        jq --raw-output '
+          (["NAME","INSTALLED","FIXED IN","VULNERABILITY"] | join(" | ") | "| " + . + " |"),
+          (["---","---","---","---"] | join(" | ") | "| " + . + " |"),
+          (
+            .matches
+            | map(select(.vulnerability.severity != "Negligible" and .vulnerability.severity != "negligible"))
+            | sort_by([
+                -(.vulnerability.severity | ascii_upcase | {"CRITICAL": 4,"HIGH": 3,"MEDIUM": 2,"LOW": 1}[.] // 0),
+                .vulnerability.id,
+                .artifact.name
+              ])
+            | .[]
+            | "| \(.artifact.name) | \(.artifact.version) | \(.vulnerability.fix.versions[0] // (if .vulnerability.fix.state == "not-fixed" then "" else "(" + .vulnerability.fix.state + ")" end)) | https://security-tracker.debian.org/tracker/\(.vulnerability.id) |"
+          )
+        ' output.json >> $GITHUB_STEP_SUMMARY
     - name: Scan Given image with grype
       shell: bash
       run: |


### PR DESCRIPTION
severity.id was automatically linked to GitHub advisories, but it is not enough to check data source because we use debian-based container as upstream.

There are cases that `.vulnerability.dataSource` points to security-tracker.d.o, but it varies on the context.
To track it consistency, explicitly set URL.